### PR TITLE
Update docs to reflect repository rename to AutoGraphPS-SDK

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,10 +20,10 @@ If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
  - OS: [e.g. Windows 10 RS 4]
- - PoshGraph Version [e.g. 0.9.2]
+ - AutoGraphPS-SDK module Version [e.g. 0.4.0]
 
 **Logs -- please attach the following data for failures executing a command
- - Output of the PoshGraph command using the `-verbose` option
+ - Output of the AutoGraphPS-SDK command using the `-verbose` option
 
 **Additional context**
 Add any other context about the problem here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in **AutoGraphPS-SDK**. This document describes the 
 
 ## What may I contribute?
 
-Contributions to AutoGraphPS-SDK may come in the form of source code, i.e. features and defect fixes, as well as [bug reports and feature requests](https://github.com/adamedx/poshgraph/issues/new/choose).
+Contributions to AutoGraphPS-SDK may come in the form of source code, i.e. features and defect fixes, as well as [bug reports and feature requests](https://github.com/adamedx/autographps-sdk/issues/new/choose).
 
 Note that all source contributions **MUST** conform to the project's [LICENSE](LICENSE.md) -- any submission in violation of the LICENSE will not be accepted.
 
@@ -92,7 +92,7 @@ AutoGraphPS-SDK is implemented using the PowerShell scripting language, and uses
 * **Use `import-script` to re-use code in other files**: The `import-script` cmdlet from [ScriptClass](https://github.com/adamedx/scriptclass) is similar conceptually to the `#include` directive in *C/C++*, the `require` statement , *Ruby*, and the `import` statement in *Python*. Use that at the top of a source file
 * **Components should be packaged as `ScriptClass` classes**: The [ScriptClass](https://github.com/adamedx/scriptclass) library allows you to use the object-oriented formalism of a *class* that defines a set of software elements based on their shared defintion of state and the operations on that state. Where in object-oriented languages like *C++*, *Java*, *C#*, *Ruby*, or *Python* you'd use the keyword `class` to declare such a set or type, in this project you'd use the keyword `ScriptClass`. As in those languages, each class should be defined in its own source files -- no source file should define more than one class or cmdlet.
 * **Cmdlets must be defined in their own source file**: An exception to the rule of packaging all functionality within a *class* type is the case of cmdlets -- any PowerShell cmdlet should be defined in its own source file. By definition, cmdlets cannot be *ScriptClass* types, but their implementation can and should make use of *ScriptClass* types defined in other files.
-* **Brace indentation - OTBS**: Use the [One True Brace Style](https://en.wikipedia.org/wiki/Indentation_style). This is what the project currently uses. It's true though that the PowerShell community [does not yet seem to have consensus](https://github.com/PoshCode/PowerShellPracticeAndStyle/issues/81) on this important issue.
+* **Brace indentation - OTBS**: Use the [One True Brace Style](https://en.wikipedia.org/wiki/Indentation_style). This is what the project currently uses. It's true though that the PowerShell community [does not yet seem to have consensus](https://github.com/Poshode/PowerShellPracticeAndStyle/issues/81) on this important issue.
 * **Follow even unwritten conventions**: As you familiarize yourself with more of the code, you may become aware of common patterns. By default, please follow them, unless you have a specific reason not to, and call out the deviation in your pull request. We can then decide whether to document the convention as-is, or modify / remove it in favor of your newer approach.
 
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,7 +2,7 @@
 
 ## In general
 
-**[AutoGraphPS-SDK](https://github.com/adamedx/poshgraph)** is a client-side tool for interacting with the [Microsoft Graph API](https://graph.microsoft.io). **AutoGraphPS-SDK** does not maintain any store of data involving your usage of the tool.
+**[AutoGraphPS-SDK](https://github.com/adamedx/autographps-sdk)** is a client-side tool for interacting with the [Microsoft Graph API](https://graph.microsoft.io). **AutoGraphPS-SDK** does not maintain any store of data involving your usage of the tool.
 
 ## Data collection
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
 AutoGraphPS-SDK
 =============
 
-<img src="https://raw.githubusercontent.com/adamedx/poshgraph-sdk/master/assets/PoshGraphIcon.png" width="100">
+<img src="https://raw.githubusercontent.com/adamedx/autographps-sdk/master/assets/PoshGraphIcon.png" width="100">
 
 ----
 
 * [Overview](#Overview)
 * [Installation](#Installation)
-* [Using PoshGraph-SDK](#using-poshgraph)
+* [Using AutoGraphPS-SDK](#using-autographps-sdk)
 * [Command inventory](#command-inventory)
 * [Developer installation from source](#developer-installation-from-source)
 * [Contributing and development](#contributing-and-development)
 * [Quickstart](#quickstart)
 * [License and authors](#license-and-authors)
 
+*This project was recently renamed from **PoshGraph-SDK** -- if you're looking for **PoshGraph-SDK**, you're in the right place!*
+
 ## Overview
 
-**AutoGraphPS-SDK** automates the [Microsoft Graph API](https://graph.microsoft.io/) through PowerShell. AutoGraphPS-SDK enables the development of PowerShell-based applications and automation of the Microsoft Graph REST API gateway; the PowerShell Graph exploration UX [AutoGraphPS](https://github.com/adamedx/poshgraph) is one such application based on the SDK. The Graph exposes a growing list of services such as
+**AutoGraphPS-SDK** automates the [Microsoft Graph API](https://graph.microsoft.io/) through PowerShell. AutoGraphPS-SDK enables the development of PowerShell-based applications and automation of the Microsoft Graph REST API gateway; the PowerShell Graph exploration UX [AutoGraphPS](https://github.com/adamedx/autographps) is one such application based on the SDK. The Graph exposes a growing list of services such as
 
 * Azure Active Directory (AAD)
 * OneDrive
@@ -31,10 +33,10 @@ The project is in the earliest stages of development and almost but not quite ye
 AutoGraphPS-SDK requires Windows 10 and PowerShell 5.0.
 
 ## Installation
-AutoGraphPS-SDK is available through the [PowerShell Gallery](https://www.powershellgallery.com/packages/poshgraph-sdk); run the following command to install the latest stable release of AutoGraphPSGraph-SDK into your user profile:
+AutoGraphPS-SDK is available through the [PowerShell Gallery](https://www.powershellgallery.com/packages/autographps-sdk); run the following command to install the latest stable release of AutoGraphPSGraph-SDK into your user profile:
 
 ```powershell
-Install-Module PoshGraph-SDK -scope currentuser
+Install-Module AutoPSGraph-SDK -scope currentuser
 ```
 
 ## Using AutoGraphPS-SDK
@@ -81,13 +83,13 @@ These commands retrieve the same data as a `GET` for the full URIs given earlier
 
 As with any PowerShell cmdlet, you can use AutoGraphPS-SDK cmdlets interactively or from within simple or even highly complex PowerShell scripts and modules since the cmdlets emit and operate upon PowerShell objects.
 
-For more detailed information on how to use AutoGraphPS-SDK cmdlets, see the [WALKTHROUGH](https://github.com/adamedx/poshgraph/blob/master/docs/WALKTHROUGH.md) for the separate AutoGraphPS module, which documents a superset of cmdlets contained in this SDK in additions to those found in that module.
+For more detailed information on how to use AutoGraphPS-SDK cmdlets, see the [WALKTHROUGH](https://github.com/adamedx/autographps/blob/master/docs/WALKTHROUGH.md) for the separate AutoGraphPS module, which documents a superset of cmdlets contained in this SDK in additions to those found in that module.
 
 ### How do I use it in my PowerShell application?
 
-If your application is packaged as a PowerShell module, simply include it in the `NestedModules` section of your module's [PowerShell module manifest](https://technet.microsoft.com/en-us/library/dd878337%28v=VS.85%29.aspx). This will allow you to publish your module to a repository like PSGallery and ensure that users who install your module from the gallery also get the installation of AutoGraphPS-SDK needed for your module to function. You should add the line `import-module poshgraph-sdk` to the beginning of the script you use to initialize your module.
+If your application is packaged as a PowerShell module, simply include it in the `NestedModules` section of your module's [PowerShell module manifest](https://technet.microsoft.com/en-us/library/dd878337%28v=VS.85%29.aspx). This will allow you to publish your module to a repository like PSGallery and ensure that users who install your module from the gallery also get the installation of AutoGraphPS-SDK needed for your module to function. You should add the line `import-module autographps-sdk` to the beginning of the script you use to initialize your module.
 
-If you're using a script module (`.psm1` file) or simply as a plan PowerShell `ps1` script, you should ensure the module has been already been installed on the system using `Install-Module` or a similar deployment mechanism, then add a line `import-module poshgraph-sdk` to the beginning of your script or script module.
+If you're using a script module (`.psm1` file) or simply as a plan PowerShell `ps1` script, you should ensure the module has been already been installed on the system using `Install-Module` or a similar deployment mechanism, then add a line `import-module autographps-sdk` to the beginning of your script or script module.
 
 ## Command inventory
 
@@ -128,8 +130,8 @@ If you'd like a behind the scenes look at the implementation of AutoGraphPS-SDK,
 For developers contributing to AutoGraphPS-SDK or those who wish to test out pre-release features that have not yet been published to PowerShell Gallery, run the following PowerShell commands to clone the repository and then build and install the module on your local system:
 
 ```powershell
-git clone https://github.com/adamedx/poshgraph-sdk
-cd poshgraph-sdk
+git clone https://github.com/adamedx/autographps-sdk
+cd autographps-sdk
 .\build\install-fromsource.ps1
 ```
 
@@ -142,9 +144,9 @@ See the [Build README](build/README.md) for instructions on building and testing
 ## Quickstart
 The Quickstart is a way to try out AutoGraphPS-SDK without installing the AutoGraphPS-SDK module. In the future it will feature an interactive tutorial. Additionally, it is useful for developers to quickly test out changes without modifying the state of the operating system or user profile. Just follow these steps on your workstation to start **AutoGraphPS-SDK**:
 
-* [Download](https://github.com/adamedx/poshgraph/archive/master.zip) and extract the zip file for this repository **OR** clone it with the following command:
+* [Download](https://github.com/adamedx/autographps-sdkarchive/master.zip) and extract the zip file for this repository **OR** clone it with the following command:
 
-  `git clone https://github.com/adamedx/poshgraph-sdk`
+  `git clone https://github.com/adamedx/autographps-sdk`
 
 * Within a **PowerShell** terminal, `cd` to the extracted or cloned directory
 * Execute the command for **QuickStart**:
@@ -168,7 +170,7 @@ This should return something like the following:
     TimeLocal  : 2/6/2018 6:05:09 AM
     TimeUtc    : 2/6/2018 6:05:09 AM
 
-If you need to launch another console with Posh Graph, you can run the faster command below which skips the build step since QuickStart already did that for you (though it's ok to run QuickStart again):
+If you need to launch another console with AutoGraphPS, you can run the faster command below which skips the build step since QuickStart already did that for you (though it's ok to run QuickStart again):
 
     .\build\import-devmodule.ps1
 

--- a/build/README.md
+++ b/build/README.md
@@ -13,11 +13,11 @@ This document describes how to build AutoGraphPS-SDK and provides additional inf
 * [Git command-line tools](https://git-for-windows.github.io/) to clone this repository locally:
 
 ```powershell
-git clone https://github.com/adamedx/poshgraph-sdk
-cd poshgraph-sdk
+git clone https://github.com/adamedx/autographps-sdk
+cd autographps-sdk
 ```
 
-**Note:** PowerShellGet version 1.6.6 is incompatible with PoshGraph due to a code defect. Versions other than 1.0.0.1 and 1.6.0 have not been tested; use 1.0.0.1 (default) or [install 1.6.0](https://www.powershellgallery.com/packages/PowerShellGet/1.6.0) in order to build this module.
+**Note:** PowerShellGet version 1.6.6 is incompatible with AutoGraphPS-SDK due to a code defect. Versions other than 1.0.0.1 and 1.6.0 have not been tested; use 1.0.0.1 (default) or [install 1.6.0](https://www.powershellgallery.com/packages/PowerShellGet/1.6.0) in order to build this module.
 
 ### Simple building and debugging
 The most common case is to build the module and then execute it in a new shell.


### PR DESCRIPTION
### Description

Fixes references in docs to the name `poshgraph-sdk`, particularly URI's referencing this repository, that should now be changed to `autographps-sdk` due to the recent rename of the module and this repository.
