### PR TITLE
Address regression in disconnecting for app-only, insufficient JSON serialization depth in graph requests

### DIFF
--- a/AutoGraphPS-SDK.psd1
+++ b/AutoGraphPS-SDK.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '0.5.0'
+ModuleVersion = '0.5.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -170,16 +170,16 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @"
-# AutoGraphPS-SDK 0.5.0 Release Notes
+# AutoGraphPS-SDK 0.5.1 Release Notes
 
 ## New features
 
-* Mounting of API versions in ``LogicalGraphManager`` now supports an optional boolean ```$verify`` parameter that verifies that the requested API version actually exists in the Graph endpoint (it makes a `GET` request on that URI). This verification is skipped by default.
+None.
 
 ## Fixed defects
 
-* Allow usage of ':' character in URIs
-* Enforce starting absolute graph paths with path separator to support use of ':' in URIs. Without this, there's no way to distinguish between the name of a Graph in a grpah absolute path since it is succeeded by a ':', e.g. '/beta:/me/contacts', and a ':' that is just part of a path, e.g. 'me/drive/root:'.
+* Connect-Graph / Disconnect-Graph fail if the current connection is app-only
+* Request body corrupted for Invoke-GraphRequest due to insufficent json serialization depth of 2 causing failed requests
 "@
 
     } # End of PSData hashtable

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,21 @@
 
 ## To-do items -- prioritized
 
-* Rename to AutoGraphPS-SDK
+* Add app creation, enumeration, update
+  * New-GraphApplication
+  * Get-GraphApplication
+  * New-GraphApplicationCertificate
+  * Get-GraphApplicationCertificate
+  * Set-GraphApplicationCertificate
+  * Get-GraphApplicationLocalCertificate
+  * Remove-GraphApplicationLocalCertificate
+  * Import-GraphApplicationLocalCertificate
+  * Remove-GraphApplication
+  * Set-GraphApplication
+  * Set-GraphApplicationPermissions
+  * Remove-GraphApplicationConsent
+
+* Extend Get-GraphToken to support all scenarios, better formats
 
 * Customize README
 * Customize WALKTHROUGH
@@ -246,6 +260,9 @@
 * Add app-only mode -- symmetric
 * Add app-only mode -- asymmetric
 * Add $search support
+* Rename to AutoGraphPS-SDK
+* Customize README
+* Customize WALKTHROUGH
 
 ### Postponed
 

--- a/src/REST/GraphRequest.ps1
+++ b/src/REST/GraphRequest.ps1
@@ -90,7 +90,7 @@ ScriptClass GraphRequest {
         $this.body = if ($body -is [string] ) {
             $body
         } else {
-            $body | convertto-json
+            $body | convertto-json -depth 20
         }
     }
 

--- a/src/REST/RESTRequest.ps1
+++ b/src/REST/RESTRequest.ps1
@@ -34,7 +34,7 @@ ScriptClass RESTRequest {
             $body | convertfrom-json | out-null
             $body
         } else {
-            $body | convertto-json
+            $body | convertto-json -depth 20
         }
 
         $this.userAgent = if ( $userAgent -ne $null ) {

--- a/src/auth/V1AuthProvider.ps1
+++ b/src/auth/V1AuthProvider.ps1
@@ -28,7 +28,7 @@ ScriptClass V1AuthProvider {
         $userId = $null
         $scopes = $null
 
-        if ( $token ) {
+        if ( $token -and $token.UserInfo ) {
             $userId = $token.UserInfo.DisplayableId
             $scopes = $null
         }

--- a/src/auth/V2AuthProvider.ps1
+++ b/src/auth/V2AuthProvider.ps1
@@ -41,7 +41,7 @@ ScriptClass V2AuthProvider {
         $userId = $null
         $scopes = $null
 
-        if ( $token ) {
+        if ( $token -and $token.User ) {
             $userId = $token.User.DisplayableId
             $scopes = $token.scopes
         }

--- a/src/client/GraphIdentity.ps1
+++ b/src/client/GraphIdentity.ps1
@@ -73,15 +73,15 @@ ScriptClass GraphIdentity {
     }
 
     function ClearAuthentication {
-        if ( $this.token ) {
+        if ( $this.token -and $this.app.AuthType -eq ([GraphAppAuthType]::Delegated) ) {
             $authUri = $this.graphEndpoint |=> GetAuthUri $this.TenantName
 
             $providerInstance = $::.AuthProvider |=> GetProviderInstance $this.graphEndpoint.AuthProtocol
             $authContext = $providerInstance |=> GetAuthContext $this.app $this.graphEndpoint.Graph $authUri
             $providerInstance |=> ClearToken $authContext $this.token
-
-            $this.token = $null
         }
+
+        $this.token = $null
     }
 
     function getGraphToken($graphEndpoint, $scopes) {


### PR DESCRIPTION
### Description

* `Connect-Graph` / `Disconnect-Graph` fail if the current connection is app-only
* Request body corrupted for `Invoke-GraphRequest` due to insufficient json serialization depth of 2 causing failed requests

### Dependency changes
None.
### Implementation notes

The regression with `Connect-Graph`, `Disconnect-Graph` for app-only was addressed by removing invalid code that attempted to remove a user when there was no user, just an app. The JSON serialization issue was fixed by simply explicitly specifying a large depth (20) to `ConvertTo-Json`.
### Checklist

- [x] All project tests pass successfully
