### PR TITLE
Fix ParseRelativeGrapLocation in GraphUtilities to hande `:` characters and add tests

### DIFF
--- a/AutoGraphPS-SDK.psd1
+++ b/AutoGraphPS-SDK.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '0.6.1'
+ModuleVersion = '0.6.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -66,7 +66,7 @@ ScriptsToProcess = @('./src/graph-sdk.ps1')
 # FormatsToProcess = @()
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
-NestedModules = @(@{ModuleName='scriptclass';ModuleVersion='0.14.1';Guid='9b0f5599-0498-459c-9a47-125787b1af19'})
+NestedModules = @(@{ModuleName='scriptclass';ModuleVersion='0.14.2';Guid='9b0f5599-0498-459c-9a47-125787b1af19'})
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = @('Get-DynamicValidateSetParameter')
@@ -210,18 +210,23 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @"
-# AutoGraphPS-SDK 0.6.1 Release Notes
+# AutoGraphPS-SDK 0.6.2 Release Notes
+
+Bug fix release to address defect in Graph URI parsing library function.
 
 ## New dependencies
 
-ScriptClass 0.14.1
+ScriptClass 0.14.2
 
 ## New features
 
+None.
+
 ## Fixed defects
 
-* Add omitted parameter completion for 'Method' parameter of ``Invoke-GraphRequest``
-* Update to ScriptClass 0.14.1 to remove slow  'import-module / remove-module' sequence  before tests that use ScriptClass mock functionality
+* Fix GraphUtilities ParseGraphRelativeLocation method to correctly handle ':' characters in the URI, add unit tests
+* Use ScriptClass 0.14.2 which fixes broken object mocks
+
 "@
 
     } # End of PSData hashtable

--- a/autographps-sdk.nuspec
+++ b/autographps-sdk.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright 2018</copyright>
     <tags>MSGraph Graph Directory PSModule</tags>
     <dependencies>
-      <dependency id="scriptclass" version="0.14.1" />
+      <dependency id="scriptclass" version="0.14.2" />
     </dependencies>
   </metadata>
   <files>

--- a/autographps-sdk.tests.ps1
+++ b/autographps-sdk.tests.ps1
@@ -29,12 +29,6 @@ Describe "Poshgraph application" {
 
     $manifest = Get-ModuleMetadataFromManifest 'autographps-sdk' $manifestlocation
 
-    BeforeAll {
-        get-job | remove-job -force
-        remove-module -force scriptclass -erroraction silentlycontinue
-        import-module -force scriptclass
-    }
-
     Context "When loading the manifest" {
         It "should export the exact same set of functions as are in the set of expected functions" {
             $expectedFunctions = @(
@@ -81,17 +75,6 @@ Describe "Poshgraph application" {
     }
 
     Context "When invoking the autographps-sdk application" {
-        BeforeEach {
-            get-job | remove-job -force
-            remove-module -force 'poshgraph' 2>$null
-            import-module $manifestlocation -force
-        }
-
-        AfterEach {
-            get-job | remove-job -force
-            remove-module -force 'autographps-sdk' 2>$null
-        }
-
         It "Should be able to create a connection object" {
             $connection = New-GraphConnection
         }

--- a/src/cmdlets/Invoke-GraphRequest.tests.ps1
+++ b/src/cmdlets/Invoke-GraphRequest.tests.ps1
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
-$manifestLocation   = Join-Path $here '..\..\autographps-sdk.psd1'
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
+. "$here\$sut"
 
 Describe 'Invoke-GraphRequest cmdlet' {
     $expectedUserPrincipalName = 'searchman@megarock.org'

--- a/src/cmdlets/Test-Graph.tests.ps1
+++ b/src/cmdlets/Test-Graph.tests.ps1
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
+. "$here\$sut"
 
 Describe "The Test-Graph cmdlet" {
-    $manifestLocation   = Join-Path $here '..\..\autographps-sdk.psd1'
     $graphPing200Response = get-content -encoding utf8 -path "$psscriptroot\..\testassets\graphping200.json"
 
     Mock Invoke-WebRequest {
@@ -24,22 +25,7 @@ Describe "The Test-Graph cmdlet" {
         $result
     }
 
-    BeforeAll {
-        remove-module -force scriptclass -erroraction silentlycontinue
-        import-module -force scriptclass
-    }
-
     Context "when receiving a successful response from Graph" {
-        BeforeAll {
-            remove-module -force 'autographps-sdk' -erroraction silentlycontinue
-            import-module scriptclass -force
-            import-module $manifestlocation -force
-        }
-
-        AfterAll {
-            remove-module -force 'autographps-sdk' -erroraction silentlycontinue
-        }
-
         It "should succeed when given no parameters" {
             { Test-Graph | out-null } | Should Not Throw
         }

--- a/src/common/GraphUtilities.tests.ps1
+++ b/src/common/GraphUtilities.tests.ps1
@@ -1,0 +1,101 @@
+# Copyright 2019, Adam Edwards
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
+. "$here\$sut"
+
+Describe 'GraphUtilities methods' {
+    Context 'When Parsing the relative Uri with the ParseGraphRelativeUri static method' {
+        $relativeUri = 'teams/74268ac2-b550-4d36-99a9-34988bab4cf5/channels/43:32872541-732c-4a76-81ea-d1881cc9e290@thread.skype'
+        $graphName = 'v2.0'
+
+        $context1 = @{Name='v1.0';Version='v1.0';location=$null}
+        $context2 = @{Name='v2.0';Version='v2.0';location=$null}
+        $contextTable = @{'v1.0'=@{Context=$context1};'v2.0'=@{Context=$context2}}
+
+        $mockGraphManager = New-ScriptObjectMock LogicalGraphManager -propertyvalues @{contexts = $contextTable}
+        Mock-ScriptClassMethod -static LogicalGraphManager Get { $mockGraphManager }
+
+        It 'Should return the default context as the context, and exactly the uri as the relativeUri preceded by "/" if the path does not start with "/"' {
+            $testUri = $relativeUri
+            $result = $::.GraphUtilities |=> ParseGraphRelativeLocation $testUri
+
+            $result.Context.version | Should Be 'v1.0'
+            $result.GraphRelativeUri | Should Be "/$testUri"
+        }
+
+        It "Should still return the default context and exactly the uri as the relative uri preceded by '/' if the path does not start with '/' even if it ends with a ':'" {
+            $testUri = ($graphName + ":"), $relativeUri -join '/'
+            $result = $::.GraphUtilities |=> ParseGraphRelativeLocation $testUri
+
+            $result.Context.version | Should Be 'v1.0'
+            $result.GraphRelativeUri | Should Be "/$testUri"
+
+        }
+
+        It "Should return the default context if the uri starts with '/' but its first segment does not end in ':'" {
+            $testUri = '/', $relativeUri -join '/'
+            $result = $::.GraphUtilities |=> ParseGraphRelativeLocation $testUri
+
+            $result.Context.version | Should Be 'v1.0'
+            $result.GraphRelativeUri | Should Be $testUri
+        }
+
+        It "Should return the default context if the uri starts with '/' but its first segment does not end in ':' even if it contains a ':' elsewhere" {
+            $testUri = 'bad:name', $relativeUri -join '/'
+            $result = $::.GraphUtilities |=> ParseGraphRelativeLocation $testUri
+
+            $result.Context.version | Should Be 'v1.0'
+            $result.GraphRelativeUri | Should Be "/$testUri"
+        }
+
+        It "Should return the specified context if the uri starts with '/' and  its first segment ends in ':'" {
+            $testUri = ('/' + $graphName + ':'), $relativeUri -join '/'
+            $result = $::.GraphUtilities |=> ParseGraphRelativeLocation $testUri
+
+            $result.Context.version | Should Be $graphName
+            $result.GraphRelativeUri | Should Be "/$relativeUri"
+        }
+
+        It "Should throw an exception if the first segment starts with '/', ends in ':', and contains another ':'" {
+            $testUri = "v2:01:", $relativeUri -join '/'
+            { $result = $::.GraphUtilities |=> ParseGraphRelativeLocation "/$testUri" } | Should Throw
+        }
+
+        It 'Should return the context and the root path "/" as the relative uri if given a path starting with "/" followed by a context name and ":" and nothing else' {
+            $testUri = ('/' + $graphName + ':')
+            $result = $::.GraphUtilities |=> ParseGraphRelativeLocation $testUri
+
+            $result.Context.version | Should Be $graphName
+            $result.GraphRelativeUri | Should Be '/'
+        }
+
+        It 'Should return the context and the root path "/" as the relative uri if given a path starting with "/" followed by a context name and ":" followed by "/"' {
+            $testUri = ('/' + $graphName + ':/')
+            $result = $::.GraphUtilities |=> ParseGraphRelativeLocation $testUri
+
+            $result.Context.version | Should Be $graphName
+            $result.GraphRelativeUri | Should Be '/'
+        }
+
+        It 'Should return the default context and a path containing a ":" if the path is simply a graph name followed by ":" and no "/" characters' {
+            $testUri = $graphName
+            $result = $::.GraphUtilities |=> ParseGraphRelativeLocation $testUri
+
+            $result.Context.version | Should Be 'v1.0'
+            $result.GraphRelativeUri | Should Be "/$graphName"
+        }
+    }
+}


### PR DESCRIPTION
… and add tests

### Description

Fix that allows users of `GraphUtilities` functions to correctly parse Graph URI's that contain ":" characters

### Dependency changes

* ScriptClass 0.14.2

### Checklist

- [x] All project tests pass successfully
