### PR TITLE
Device code user auth support

### DIFF
--- a/AutoGraphPS-SDK.psd1
+++ b/AutoGraphPS-SDK.psd1
@@ -125,6 +125,8 @@ AliasesToExport = @('gge', 'ggi')
         '.\src\cmdlets.ps1',
         '.\src\graph-sdk.ps1',
         '.\src\auth\AuthProvider.ps1',
+        '.\src\auth\CompiledDeviceCodeAuthenticator.ps1',
+        '.\src\auth\DeviceCodeAuthenticator.ps1',
         '.\src\auth\V1AuthProvider.ps1',
         '.\src\auth\V2AuthProvider.ps1',
         '.\src\client\Application.ps1',

--- a/AutoGraphPS-SDK.psd1
+++ b/AutoGraphPS-SDK.psd1
@@ -216,16 +216,16 @@ PrivateData = @{
 
 ## New dependencies
 
-* Microsoft.Identity.Client.2.6.2
-* Microsoft.IdentityModel.Clients.ActiveDirectory.4.4.2
+* Microsoft.Identity.Client.2.7.0
 
 ## New features
 
 * Device code authentication support for user sign-in on devices without a web browser: Use the ``-NoBrowserSigninUI`` option for user authentication with the following cmdlets: ``Connect-Graph``, ``New-GraphConnection``, and ``Get-GraphToken``.
+* Command-line help for Test-Graph, Get-GraphError
 
 ## Fixed defects
 
-* Fixed defect in parameter completion where some parameters were not completed, added tests to prevent regression
+* Fix broken error messages in Get-GraphSchema
 
 "@
 

--- a/AutoGraphPS-SDK.psd1
+++ b/AutoGraphPS-SDK.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '0.8.2'
+ModuleVersion = '0.9.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -212,16 +212,16 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @"
-# AutoGraphPS-SDK 0.8.2 Release Notes
+# AutoGraphPS-SDK 0.9.0 Release Notes
 
 ## New dependencies
 
-Microsoft.Identity.Client.2.6.2
-Microsoft.IdentityModel.Clients.ActiveDirectory.4.4.2
+* Microsoft.Identity.Client.2.6.2
+* Microsoft.IdentityModel.Clients.ActiveDirectory.4.4.2
 
 ## New features
 
-None.
+* Device code authentication support for user sign-in on devices without a web browser: Use the ``-NoBrowserSigninUI`` option for user authentication with the following cmdlets: ``Connect-Graph``, ``New-GraphConnection``, and ``Get-GraphToken``.
 
 ## Fixed defects
 

--- a/autographps-sdk.nuspec
+++ b/autographps-sdk.nuspec
@@ -24,7 +24,7 @@
     <file src="autographps-sdk.tests.ps1" target="." />
     <file src="src\**\*.ps1" target="src/" />
     <file src="build\**\*.ps1" target="build/" />
-    <file src="lib\Microsoft.Identity.Client.2.6.2\lib\net45\*.dll" target="lib/Microsoft.Identity.Client.2.6.2\lib\net45" />
+    <file src="lib\Microsoft.Identity.Client.2.7.0\lib\net45\*.dll" target="lib/Microsoft.Identity.Client.2.7.0\lib\net45" />
     <file src="lib\Microsoft.IdentityModel.Clients.ActiveDirectory.4.4.2\lib\net45\*.dll" target="lib/Microsoft.IdentityModel.Clients.ActiveDirectory.4.4.2\lib\net45" />
   </files>
 </package>

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="4.4.2" targetFramework="net45" />
-  <package id="Microsoft.Identity.Client" version="2.6.2" targetFramework="net45" />
+  <package id="Microsoft.Identity.Client" version="2.7.0" targetFramework="net45" />
 </packages>

--- a/src/auth/AuthProvider.ps1
+++ b/src/auth/AuthProvider.ps1
@@ -33,8 +33,12 @@ ScriptClass AuthProvider {
         $this.derivedProvider |=> GetUserInformation $token
     }
 
-    function AcquireFirstUserToken($authContext, $scopes) {
-        $this.derivedProvider |=> AcquireFirstUserToken $authContext $scopes
+    function AcquireFirstUserToken($authContext, $scopes, $useDeviceCodeUI) {
+        if ( $useDeviceCodeUI ) {
+            $this.derivedProvider |=> AcquireFirstUserTokenFromDeviceCode $authContext $scopes
+        } else {
+            $this.derivedProvider |=> AcquireFirstUserToken $authContext $scopes
+        }
     }
 
     function AcquireFirstUserTokenConfidential($authContext, $scopes) {

--- a/src/auth/CompiledDeviceCodeAuthenticator.ps1
+++ b/src/auth/CompiledDeviceCodeAuthenticator.ps1
@@ -1,0 +1,51 @@
+# Copyright 2019, Adam Edwards
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+$dotnetPlatform = if ( $PSVersionTable.PSEdition -eq 'Core' ) {
+    'netcoreapp1.0'
+} else {
+    'net45'
+}
+
+$authLibraryPath = [System.Reflection.Assembly]::GetAssembly(([Microsoft.Identity.Client.PublicClientApplication])).location
+
+# Use C# here due to threading complications when using AcquireTokenWithDeviceCodeAsync
+try {
+    add-type -referencedassemblies $authLibraryPath, System.Console, System.Threading.Tasks -ignorewarnings @'
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.Identity.Client;
+
+    public class CompiledDeviceCodeAuthenticator
+    {
+        public static Task ShowMessage(DeviceCodeResult deviceCodeResult)
+        {
+            Console.WriteLine(deviceCodeResult.Message);
+            return Task.FromResult(0);
+        }
+
+        public static Task<AuthenticationResult> GetTokenWithCode(PublicClientApplication authContext, string[] scopes)
+        {
+            var asyncResult = authContext.AcquireTokenWithDeviceCodeAsync(
+                scopes,
+                ShowMessage);
+
+            return asyncResult;
+        }
+    }
+'@ 3> $null
+} catch {
+    write-warning "Unable to compile code for device code authentication flow -- device code signin will be disabled"
+    write-warning $_.Exception
+}

--- a/src/auth/DeviceCodeAuthenticator.ps1
+++ b/src/auth/DeviceCodeAuthenticator.ps1
@@ -1,0 +1,37 @@
+# Copyright 2019, Adam Edwards
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ScriptClass DeviceCodeAuthenticator {
+    static {
+        $initialized = $false
+
+        function Authenticate($authContext, $scopes) {
+            if ( ! $this.initialized ) {
+                . $psscriptroot/CompiledDeviceCodeAuthenticator.ps1
+                $this.initialized = $true
+            }
+
+            $asyncResult = [CompiledDeviceCodeAuthenticator]::GetTokenWithCode($authContext, $scopes)
+
+            # Need to sleep periodically otherwise console signals like SIG-INT / CTRL-C
+            # won't work and you'll be hung if you want to cancel -- you'll have to terminate
+            # the process :(.
+            while ( ! $asyncResult.IsCompleted ) {
+                start-sleep -milliseconds 500
+            }
+
+            $asyncResult
+        }
+    }
+}

--- a/src/auth/V1AuthProvider.ps1
+++ b/src/auth/V1AuthProvider.ps1
@@ -55,6 +55,10 @@ ScriptClass V1AuthProvider {
             $promptBehavior)
     }
 
+    function AcquireFirstUserTokenFromDeviceCode($authContext, $scopes) {
+        throw [NotImplementedException]::new("Device code authentication is not implemented for the v1 authentication protocol.")
+    }
+
     function AcquireFirstAppToken($authContext) {
         write-verbose 'V1 auth provider acquiring initial app token'
 

--- a/src/auth/V2AuthProvider.ps1
+++ b/src/auth/V2AuthProvider.ps1
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 . (import-script AuthProvider)
+. (import-script DeviceCodeAuthenticator)
 
 ScriptClass V2AuthProvider {
     $base = $null
@@ -63,6 +64,11 @@ ScriptClass V2AuthProvider {
         $scopeList = $this.__ScopesAsScopeList.InvokeReturnAsIs(@($scopes))
 
         $authContext.protocolContext.AcquireTokenAsync($scopeList)
+    }
+
+    function AcquireFirstUserTokenFromDeviceCode($authContext, $scopes) {
+        write-verbose 'V2 auth provider acquiring initial user token using device code'
+        $::.DeviceCodeAuthenticator |=> Authenticate $authContext.protocolcontext $scopes
     }
 
     function AcquireFirstAppToken($authContext) {

--- a/src/client/Application.ps1
+++ b/src/client/Application.ps1
@@ -15,5 +15,6 @@
 ScriptClass Application {
     static {
         const AppId (strict-val [Guid] '9825d80c-5aa0-42ef-bf13-61e12116704c')
+        $SupportsBrowserSignin = $PSVersionTable.PSEdition -eq 'Desktop'
     }
 }

--- a/src/client/Application.ps1
+++ b/src/client/Application.ps1
@@ -14,7 +14,7 @@
 
 ScriptClass Application {
     static {
-        const AppId (strict-val [Guid] '9825d80c-5aa0-42ef-bf13-61e12116704c')
+        const DefaultAppId (strict-val [Guid] '9825d80c-5aa0-42ef-bf13-61e12116704c')
         $SupportsBrowserSignin = $PSVersionTable.PSEdition -eq 'Desktop'
     }
 }

--- a/src/client/GraphConnection.ps1
+++ b/src/client/GraphConnection.ps1
@@ -96,7 +96,7 @@ ScriptClass GraphConnection {
     static {
         function NewSimpleConnection([GraphType] $graphType = 'MSGraph', [GraphCloud] $cloud = 'Public', [String[]] $ScopeNames, $anonymous = $false, $tenantName = $null, $authProtocol = $null ) {
             $endpoint = new-so GraphEndpoint $cloud $graphType $null $null $authProtocol
-            $app = new-so GraphApplication $::.Application.AppId
+            $app = new-so GraphApplication $::.Application.DefaultAppId
             $identity = if ( ! $anonymous ) {
                 new-so GraphIdentity $app $endpoint $tenantName
             }

--- a/src/client/GraphConnection.ps1
+++ b/src/client/GraphConnection.ps1
@@ -26,12 +26,14 @@ ScriptClass GraphConnection {
     $Scopes = $null
     $Connected = $false
     $Status = [GraphConnectionStatus]::Online
+    $NoBrowserUI = $false
 
-    function __initialize([PSCustomObject] $graphEndpoint, [PSCustomObject] $Identity, [Object[]]$Scopes) {
+    function __initialize([PSCustomObject] $graphEndpoint, [PSCustomObject] $Identity, [Object[]]$Scopes, $noBrowserUI = $false) {
         $this.GraphEndpoint = $graphEndpoint
         $this.Identity = $Identity
         $this.Connected = $false
         $this.Status = [GraphConnectionStatus]::Online
+        $this.NoBrowserUI = ! $::.Application.SupportsBrowserSignin -or $noBrowserUI
 
         if ( $this.GraphEndpoint.Type -eq ([GraphType]::MSGraph) ) {
             if ( $Identity -and ! $scopes ) {
@@ -44,7 +46,7 @@ ScriptClass GraphConnection {
     function Connect {
         if ( ($this.Status -eq [GraphConnectionStatus]::Online) -and (! $this.connected) ) {
             if ($this.Identity) {
-                $this.Identity |=> Authenticate $this.Scopes
+                $this.Identity |=> Authenticate $this.Scopes $this.NoBrowserUI
             }
             $this.connected = $true
         }
@@ -58,7 +60,7 @@ ScriptClass GraphConnection {
         if ( $this.Status -eq [GraphConnectionStatus]::Online ) {
             if ( $this.GraphEndpoint.Type -eq [GraphType]::MSGraph ) {
                 # Trust the library's token cache to get a new token if necessary
-                $this.Identity |=> Authenticate $this.Scopes $true
+                $this.Identity |=> Authenticate $this.Scopes $this.NoBrowserUI
                 $this.connected = $true
             } else {
                 Connect

--- a/src/client/GraphIdentity.ps1
+++ b/src/client/GraphIdentity.ps1
@@ -55,7 +55,7 @@ ScriptClass GraphIdentity {
         }
     }
 
-    function Authenticate($scopes = $null) {
+    function Authenticate($scopes = $null, $noBrowserUI = $false) {
         if ( $this.token ) {
             $tokenTimeLeft = $this.token.expireson - [DateTime]::UtcNow
             write-verbose ("Found existing token with {0} minutes left before expiration" -f $tokenTimeLeft.TotalMinutes)
@@ -63,7 +63,7 @@ ScriptClass GraphIdentity {
 
         write-verbose ("Getting token for resource {0} from auth endpoint: {1} with protocol {2}" -f $this.graphEndpoint.Graph, $this.graphEndpoint.Authentication, $this.graphEndpoint.AuthProtocol)
 
-        $this.Token = getGraphToken $this.graphEndpoint $scopes
+        $this.Token = getGraphToken $this.graphEndpoint $scopes $noBrowserUI
 
         if ($this.token -eq $null) {
             throw "Failed to acquire token, no additional error information"
@@ -84,7 +84,7 @@ ScriptClass GraphIdentity {
         $this.token = $null
     }
 
-    function getGraphToken($graphEndpoint, $scopes) {
+    function getGraphToken($graphEndpoint, $scopes, $noBrowserUI) {
         write-verbose "Attempting to get token for '$($graphEndpoint.Graph)' ..."
         write-verbose "Using app id '$($this.App.AppId)'"
         $isConfidential = ($this.app |=> IsConfidential)
@@ -108,7 +108,7 @@ ScriptClass GraphIdentity {
                 if ( $isConfidential ) {
                     $providerInstance |=> AcquireFirstUserTokenConfidential $authContext $scopes
                 } else {
-                    $providerInstance |=> AcquireFirstUserToken $authContext $scopes
+                    $providerInstance |=> AcquireFirstUserToken $authContext $scopes $noBrowserUI
                 }
             }
         }

--- a/src/cmdlets/Connect-Graph.ps1
+++ b/src/cmdlets/Connect-Graph.ps1
@@ -42,6 +42,9 @@ function Connect-Graph {
         [parameter(parametersetname='reconnect', mandatory=$true)]
         [Switch] $Reconnect,
 
+        [parameter(parametersetname='simple')]
+        [Switch] $NoBrowserSigninUI,
+
         [parameter(parametersetname='apponly', mandatory=$true)]
         [Switch] $NoninteractiveAppOnlyAuth,
 
@@ -100,7 +103,7 @@ function Connect-Graph {
                 if ( $Permissions -and $context.connection -and $context.connection.identity ) {
                     write-verbose 'Creating connection from existing connection but with new permissions'
                     $identity = new-so GraphIdentity $context.connection.identity.app $context.connection.graphEndpoint $context.connection.identity.tenantname
-                    new-so GraphConnection $context.connection.graphEndpoint $identity $computedScopes
+                    new-so GraphConnection $context.connection.graphEndpoint $identity $computedScopes $NoBrowserSigninUI.IsPresent
                 } else {
                     write-verbose 'Just reconnecting the existing connection'
                     $context.connection
@@ -116,6 +119,7 @@ function Connect-Graph {
                 } else {
                     $delegatedArguments['Permissions'] = $computedScopes
                     $delegatedArguments['Confidential'] = $Confidential
+                    $delegatedArguments['NoBrowserSigninUI'] = $NoBrowserSigninUI
                     if ( $TenantId ) {
                         $delegatedArguments['TenantId'] = $TenantId
                     }

--- a/src/cmdlets/Connect-Graph.ps1
+++ b/src/cmdlets/Connect-Graph.ps1
@@ -95,7 +95,7 @@ function Connect-Graph {
             $applicationId = if ( $AppId ) {
             [Guid] $AppId
             } else {
-                $::.Application.AppId
+                $::.Application.DefaultAppId
             }
 
             $newConnection = if ( $Reconnect.IsPresent ) {

--- a/src/cmdlets/Get-GraphError.ps1
+++ b/src/cmdlets/Get-GraphError.ps1
@@ -105,7 +105,7 @@ The Get-GraphError command was invoked after the following Graph command failed:
 
 Invoke-GraphRequest was invoked to POST to the 'me/contacts' relative URI of https://graph.microsoft.com/v1.0 with a Body parameter that specifies the first and last name of a personal contact. The command should create a new contact resource, but received a 'BadRequest' status code of 400 from Graph and threw and exception.
 
-By executing the Get-GraphError command after receiving the error, the operator is able to see additional detail beyond the status code and the line number on which the error occurred. The ResponseStream property often has detailed information about the error, and in this case it contains an error message "The property 'firstName' does not exist on type 'Microsoft.OutlookServices.Contact'". This guides the operator to look more clsoely at the documentation for the contat resource, which instead of a 'firstName' property contains a 'givenName' property.
+By executing the Get-GraphError command after the failed command, the operator is able to see additional information beyond the status code and the line number on which the error occurred. The ResponseStream property often has detailed information about the error, and in this case it contains an error message "The property 'firstName' does not exist on type 'Microsoft.OutlookServices.Contact'". This guides the operator to look more clsoely at the documentation for the contat resource, which instead of a 'firstName' property contains a 'givenName' property.
 
 The operator can then correct the error in the original Invoke-GraphRequest command, replacing 'firstName' with 'givenName' in the Body parameter and the command will succeed.
 

--- a/src/cmdlets/Get-GraphError.ps1
+++ b/src/cmdlets/Get-GraphError.ps1
@@ -61,4 +61,57 @@ function Get-GraphError {
             }
         )
     }
+
+<#
+.SYNOPSIS
+Retrieves the error response from Graph for the last failed REST call invoked by one of this module's commands.
+
+.DESCRIPTION
+When a command such as Get-GraphItem or Invoke-GraphRequest fails due to an error response from Graph, i.e. a status code other than 2xx is returned, this command outputs the full response stream from the failed call to assist in troubleshooting the failure. This output may include details such as error messages on the specifics of an incorrectly specified parameter or unsupported scenario.
+
+.OUTPUTS
+If the last Graph request from this module was successful, this command returns no output. If there was a failure, the result of this command is an object that contains a System.Net.HttpWebResponse object, and also important fields obtained from that object such as the response headers, the time at which the error occurred, and the deserialized response.
+
+.EXAMPLE
+Get-GraphError
+
+AfterTimeLocal    : 1/25/2019 5:48:38 AM
+AfterTimeUtc      : 1/25/2019 1:48:38 PM
+PSErrorRecord     : The remote server returned an error: (400) Bad Request.
+Response          : System.Net.HttpWebResponse
+ResponseHeaders   : @{x-ms-ags-diagnostic=x-ms-ags-diagnostic;
+                    Transfer-Encoding=Transfer-Encoding; request-id=request-id;
+                    Content-Type=Content-Type; Cache-Control=Cache-Control;
+                    Strict-Transport-Security=Strict-Transport-Security; Date=Date;
+                    Duration=Duration; client-request-id=client-request-id}
+ResponseStream    : {
+                      "error": {
+                        "code": "RequestBodyRead",
+                        "message": "The property 'firstName' does not exist on type
+                    'Microsoft.OutlookServices.Contact'. Make sure to only use property names
+                    that are defined by the type or mark the type as open type.",
+                        "innerError": {
+                          "request-id": "b01e4465-3543-4eda-abd8-b26d1ffb9a82",
+                          "date": "2019-01-25T13:48:39"
+                        }
+                      }
+                    }
+StatusCode        : BadRequest
+StatusDescription : Bad Request
+
+The Get-GraphError command was invoked after the following Graph command failed:
+
+    Invoke-GraphRequest -Method POST me/contacts -Body @{firstName='Cleopatra';surname='Jones'}
+
+Invoke-GraphRequest was invoked to POST to the 'me/contacts' relative URI of https://graph.microsoft.com/v1.0 with a Body parameter that specifies the first and last name of a personal contact. The command should create a new contact resource, but received a 'BadRequest' status code of 400 from Graph and threw and exception.
+
+By executing the Get-GraphError command after receiving the error, the operator is able to see additional detail beyond the status code and the line number on which the error occurred. The ResponseStream property often has detailed information about the error, and in this case it contains an error message "The property 'firstName' does not exist on type 'Microsoft.OutlookServices.Contact'". This guides the operator to look more clsoely at the documentation for the contat resource, which instead of a 'firstName' property contains a 'givenName' property.
+
+The operator can then correct the error in the original Invoke-GraphRequest command, replacing 'firstName' with 'givenName' in the Body parameter and the command will succeed.
+
+.LINK
+Get-GraphItem
+Invoke-GraphRequest
+Remove-GraphItem
+#>
 }

--- a/src/cmdlets/Get-GraphSchema.ps1
+++ b/src/cmdlets/Get-GraphSchema.ps1
@@ -110,14 +110,14 @@ function Get-GraphSchema {
     $results = @()
     $graphNamespaces | foreach {
         $graphSchemaVersion = $graphSchemaVersions[$_]
-        $apiVersionDisplay = if ( $apiVersion -ne $null ) {
-            "'$apiVersion'"
+        $apiVersionDisplay = if ( $apiVersion ) {
+            "$apiVersion"
         } else {
             'v1.0'
         }
 
         if ($graphSchemaVersion -eq $null) {
-            throw "Specified namespace '$_' does not exist in the provided version '$apiVersionDisplay'"
+            throw "Specified namespace '$_' does not exist in the provided Graph API version '$apiVersionDisplay'"
         }
 
         $relativeUri = $relativeBase, $_, $graphSchemaVersion -join '/'

--- a/src/cmdlets/Get-GraphToken.ps1
+++ b/src/cmdlets/Get-GraphToken.ps1
@@ -52,6 +52,9 @@ function Get-GraphToken {
 
         [Uri] $AppRedirectUri,
 
+        [parameter(parametersetname='msgraph')]
+        [Switch] $NoBrowserSigninUI,
+
         [parameter(parametersetname='secret', mandatory=$true)]
         [parameter(parametersetname='cert', mandatory=$true)]
         [parameter(parametersetname='certpath', mandatory=$true)]

--- a/src/cmdlets/New-GraphConnection.ps1
+++ b/src/cmdlets/New-GraphConnection.ps1
@@ -57,6 +57,9 @@ function New-GraphConnection {
 
         [Uri] $AppRedirectUri,
 
+        [parameter(parametersetname='msgraph')]
+        [Switch] $NoBrowserSigninUI,
+
         [parameter(parametersetname='secret', mandatory=$true)]
         [parameter(parametersetname='cert', mandatory=$true)]
         [parameter(parametersetname='certpath', mandatory=$true)]
@@ -180,7 +183,7 @@ function New-GraphConnection {
 
             $app = new-so GraphApplication $newAppId $AppRedirectUri $appSecret $NoninteractiveAppOnlyAuth.IsPresent
             $identity = new-so GraphIdentity $app $graphEndpoint $adjustedTenantId
-            new-so GraphConnection $graphEndpoint $identity $specifiedScopes
+            new-so GraphConnection $graphEndpoint $identity $specifiedScopes $NoBrowserSigninUI.IsPresent
         }
     }
 }

--- a/src/cmdlets/New-GraphConnection.ps1
+++ b/src/cmdlets/New-GraphConnection.ps1
@@ -178,7 +178,7 @@ function New-GraphConnection {
             $newAppId = if ( $appId ) {
                 $appId
             } else {
-                $::.Application.AppId
+                $::.Application.DefaultAppId
             }
 
             $app = new-so GraphApplication $newAppId $AppRedirectUri $appSecret $NoninteractiveAppOnlyAuth.IsPresent

--- a/src/cmdlets/Test-Graph.ps1
+++ b/src/cmdlets/Test-Graph.ps1
@@ -78,4 +78,72 @@ function Test-Graph {
     } else {
         $response.content
     }
+
+<#
+.SYNOPSIS
+Determines without authentication whether a Graph endpoint is accessible over the network.
+
+.DESCRIPTION
+The Test-Graph cmdlet makes a simple GET request to a specified Graph endpoint's 'ping' URL. If a successful (HTTP status code 200) response is received, parameters of the response are returned by the cmdlet.
+
+.PARAMETER Cloud
+Specifies that the target Graph endpoint to test is the Graph endpoint associated with cloud environment indicated by the parameter. By default, Test-Graph makes a request against the current connection, which itself defaults to https://graph.microsoft.com, so this parameter allows the default to be overridden.
+
+.PARAMETER Connection
+Specifies a Connection object returned by the New-GraphConnection command whose endpoint will be accessed by the endpoint.
+
+.PARAMETER EndpointUri
+Specifies an arbitrary URI as the Graph endpoint -- the URI must be an absolute URI, e.g. https://graph.microsoft.com.
+
+.PARAMETER RawContent
+By default, the output of the cmdlet is deserialized PowerShell objects. If this switch is specified, the output is the response JSON formatted value returned by the Graph endpoint without deserialization.
+
+.OUTPUTS
+If successful, this cmdlet returns deserialized PowerShell objects that provide diagnostic information about the Graph endpoint such as the name of the datacenter that served the request, the time of the request as seen by the system that served the response, and the host name of the system that served the response. The output may be piped to other commands including Select-Object to project specific fields or perform other additional processing.
+If the command is not successful, an HTTP status code will be surfaced in an exception. Failure indicates that the Graph endpoint may not be reachable from the system on which this cmdlet was executed, or that the Graph service is being disrupted.
+
+.EXAMPLE
+Test-Graph
+
+ADSiteName : wus
+Build      : 1.0.9954.5
+DataCenter : west us
+Host       : agsfe_in_38
+PingUri    : https://graph.microsoft.com/ping
+Ring       : 5
+ScaleUnit  : 002
+Slice      : slicec
+TimeLocal  : 1/24/2019 6:54:13 AM
+TimeUtc    : 1/24/2019 6:54:13 AM
+
+When no parameters are specified, the command targets the Graph endpoint of the current connection, in this case https://graph.microsoft.com, and outputs diagnostic information.
+
+.EXAMPLE
+Test-Graph -Cloud GermanyCloud
+
+ADSiteName : dne
+Build      : 1.0.9954.4
+DataCenter : germany northeast
+Host       : agsfe_in_3
+PingUri    : https://graph.microsoft.de/ping
+Ring       : 4
+ScaleUnit  : 000
+Slice      : slicec
+TimeLocal  : 1/24/2019 7:04:06 AM
+TimeUtc    : 1/24/2019 7:04:06 AM
+
+This command targets the Graph endpoint for the Germany cloud, https://graph.microsoft.de, ando outputs its diagnostic information.
+
+.EXAMPLE
+Test-Graph -RawContent
+
+{"Time-Local":"1/24/2019 7:06:20 AM","Time-UTC":"1/24/2019 7:06:20 AM","Build":"1.0.9954.5","DataCenter":"west us","Slice":"slicec","Ring":"5","ScaleUnit":"001","Host":"agsfe_in_0","ADSiteName":"wus"}
+
+This command returns the same information as in the first example, but by specifying the RawContent parameter the command is directed not to output the response as deserialized structured objects, but in the exact format in which it was returned by Graph, in this case JSON.
+
+.LINK
+Get-GraphConnectionInfo
+New-GraphConnection
+Connect-Graph
+#>
 }


### PR DESCRIPTION
### Description

Enable use of device code auth for user auth scenarios where there is no web browser integration with the auth library including Linux:

* Device code authentication support for user sign-in on devices without a web browser: Use the `-NoBrowserSigninUI` option for user authentication with the following cmdlets: `Connect-Graph`, `New-GraphConnection`, and `Get-GraphToken`. 

### Dependency changes

* Microsoft.Identity.Client 2.7.0

### Implementation notes

Makes use of MSAL library's device code auth support and defaults to using it on PowerShell core (including Linux)

### Checklist

- [x] All project tests pass successfully
