### PR TITLE
Add value support for GET requests, national cloud fixes

### DIFF
--- a/AutoGraphPS-SDK.psd1
+++ b/AutoGraphPS-SDK.psd1
@@ -231,6 +231,7 @@ None.
 ## Fixed defects
 
 * Fixed hang in PS remote sessions when performing delegated user auth via device code
+* Fixed broken v2 auth for national clouds due to incorrectly qualified scopes
 
 "@
 

--- a/AutoGraphPS-SDK.psd1
+++ b/AutoGraphPS-SDK.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '0.9.1'
+ModuleVersion = '0.10.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -167,6 +167,7 @@ AliasesToExport = @('gge', 'ggi')
         '.\src\cmdlets\common\ConsentHelper.ps1',
         '.\src\cmdlets\common\DisplayTypeFormatter.ps1',
         '.\src\cmdlets\common\DynamicParamHelper.ps1',
+        '.\src\cmdlets\common\GraphOutputFile.ps1',
         '.\src\cmdlets\common\ItemResultHelper.ps1',
         '.\src\cmdlets\common\ParameterCompleter.ps1',
         '.\src\cmdlets\common\PermissionParameterCompleter.ps1',
@@ -212,7 +213,7 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @"
-# AutoGraphPS-SDK 0.9.1 Release Notes
+# AutoGraphPS-SDK 0.10.0 Release Notes
 
 ## New dependencies
 
@@ -221,6 +222,9 @@ None.
 ## New features
 
 * Auto-detect PS remote sessions and invoke device code auth for delegated user auth scenarios
+* Value parameter for Invoke-GraphRequest, Get-GraphItem to make `$value requests
+* OutputFilePrefix parameter for Invoke-GraphRequest, Get-GraphItem for sending output to the file system
+* IncludeFullResponse parameter for Invoke-GraphRequest to allow retrieval of the full response object in the output
 * Build script improvements -- tools obtain a specific nuget version and use it only in the context of this repository
 * Azure Pipelines integration -- basic continuous integration support added.
 

--- a/src/auth/V2AuthProvider.ps1
+++ b/src/auth/V2AuthProvider.ps1
@@ -60,10 +60,9 @@ ScriptClass V2AuthProvider {
             throw [ArgumentException]::new('No scopes specified for v2 auth protocol, at least one scope is required')
         }
 
-        # See comment on __ScopesAsScopeList member to understand strange call syntax here
-        $scopeList = $this.__ScopesAsScopeList.InvokeReturnAsIs(@($scopes))
+        $scopeList = $::.ScopeHelper |=> QualifyScopes $scopes $authContext.GraphEndpointUri
 
-        $authContext.protocolContext.AcquireTokenAsync($scopeList)
+        $authContext.protocolContext.AcquireTokenAsync([System.Collections.Generic.List[string]] $scopeList)
     }
 
     function AcquireFirstUserTokenFromDeviceCode($authContext, $scopes) {
@@ -73,15 +72,15 @@ ScriptClass V2AuthProvider {
 
     function AcquireFirstAppToken($authContext) {
         write-verbose 'V2 auth provider acquiring initial app token'
-        $defaultScopeList = $this.__GetDefaultScopeList.InvokeReturnAsIs(@($authContext))
+        $defaultScopeList = $this |=> __GetDefaultScopeList $authContext
 
-        $authContext.protocolContext.AcquireTokenForClientAsync($defaultScopeList)
+        $authContext.protocolContext.AcquireTokenForClientAsync([System.Collections.Generic.List[string]] $defaultScopeList)
     }
 
     function AcquireFirstUserTokenConfidential($authContext, $scopes) {
         write-verbose 'V2 auth provider acquiring user token via confidential client'
 
-        $scopeList = $this.__ScopesAsScopeList.InvokeReturnAsIs(@($scopes))
+        $scopeList = $::.ScopeHelper |=> QualifyScopes $scopes $authContext.GraphEndpointUri
 
         # Confidential user flow uses an authcode flow with a confidential rather than public client.
         # First, get the auth code for the user -- MSAL does not support this, but it does return the URI
@@ -99,19 +98,19 @@ ScriptClass V2AuthProvider {
         $authCodeInfo = GetAuthCodeFromURIUserInteraction $authCodeUxUri
 
         # 3. Now use MSAL's confidential client to obtain the token from the auth code
-        $authContext.protocolContext.AcquireTokenByAuthorizationCodeAsync($authCodeInfo.ResponseParameters.Code, $scopeList)
+        $authContext.protocolContext.AcquireTokenByAuthorizationCodeAsync($authCodeInfo.ResponseParameters.Code, [System.Collections.Generic.List[string]] $scopeList)
     }
 
     function AcquireRefreshedToken($authContext, $token) {
         write-verbose 'V2 auth provider refreshing existing token'
 
         if ( $authContext.app.authtype -eq ([GraphAppAuthType]::AppOnly) ) {
-            $defaultScopeList = $this.__GetDefaultScopeList.InvokeReturnAsIs(@($authContext, @()))
-            $authContext.protocolContext.AcquireTokenForClientAsync($defaultScopeList)
+            $defaultScopeList = $this |=> __GetDefaultScopeList $authContext @()
+            $authContext.protocolContext.AcquireTokenForClientAsync([System.Collections.Generic.List[string]] $defaultScopeList)
         } else {
-            # See comment on __ScopesAsScopeList member to understand strange call syntax here
-            $requestedScopesFromToken = $this.__ScopesAsScopeList.InvokeReturnAsIs(@($token.scopes))
-            $authContext.protocolContext.AcquireTokenSilentAsync($requestedScopesFromToken, $token.account)
+            $requestedScopesFromToken = $::.ScopeHelper |=> QualifyScopes $token.scopes $authContext.GraphEndpointUri |
+              where { $_ -notin @('openid', 'profile', 'offline_access') }
+            $authContext.protocolContext.AcquireTokenSilentAsync([System.Collections.Generic.List[string]] $requestedScopesFromToken, $token.account)
         }
     }
 
@@ -124,48 +123,8 @@ ScriptClass V2AuthProvider {
         $asyncRemoveResult.Wait()
     }
 
-    $__GetDefaultScopeList = {
-        param($authContext)
-        # See comments for $__ScopesAsScopeList as to why this is a script block instead
-        # of a function and has a strange return value
-        $scopes = new-object System.Collections.Generic.List[string]
-        $defaultScope = $authContext.GraphEndpointUri.tostring().trimend('/'), '.default' -join '/'
-        $scopes.Add($defaultScope)
-
-        # This is not a typo -- see $__ScopesAsScopeList member block comments
-        return , $scopes
-    }
-
-    $__ScopesAsScopeList = {
-        param($scopes)
-        $scopeList = new-object System.Collections.Generic.List[string]
-        $alreadyPresentScopes = @('openid', 'profile', 'offline_access')
-        $scopes | where { $alreadyPresentScopes -notcontains $_ } | foreach {
-            $scopeList.Add($_)
-        }
-
-        # OK, this last line is *strange*. Yes, the syntax with the comma is correct. This
-        # is a trick to get PowerShell to not convert this .NET generic List class to an array,
-        # or, in the case of a List with one element simply a single object of that element!
-        # In our case, the caller *really* wants this to be the List type as it will be
-        # passed to a .NET metho, which means the argument is type checked and the call will
-        # fail the call if the argument is not the expected .NET type. See the issue below:
-        #
-        #    https://stackoverflow.com/questions/16121969/function-not-returning-expected-object
-        #
-        # Additionally, the problem persists if this is a function. And if you make it a script
-        # block and call Invoke, it still happens! The only way I've found around this is the following,
-        # which also reveals why this is a script block rather than a function :) :
-        #
-        #   * Make this a script block rather than a function
-        #   * Return the value by explicitly using return, and passing the result preceded by ",", i.e. "return , $myresult"
-        #   * Invoke it with the InvokeReturnAsIs method instead of Invoke to preserve the actual type of the return value
-        #
-        # This is a really unfortunate behavior -- I'm surprised I haven't run into it
-        # before, but probably only an issue when doing interop with actual .NET code
-        # as in our case.
-
-        return , $scopeList
+    function __GetDefaultScopeList($authContext) {
+        $::.ScopeHelper |=> QualifyScopes @('.default') $authContext.GraphEndpointUri
     }
 
     function GetAuthCodeFromURIUserInteraction($authUxUri) {

--- a/src/cmdlets/Get-GraphItem.ps1
+++ b/src/cmdlets/Get-GraphItem.ps1
@@ -36,6 +36,10 @@ function Get-GraphItem {
 
         [Switch] $Descending,
 
+        [Switch] $Value,
+
+        $OutputFilePrefix,
+
         [String] $Query = $null,
 
         [HashTable] $Headers = $null,
@@ -70,6 +74,8 @@ function Get-GraphItem {
         Expand = $Expand
         OrderBy = $OrderBy
         Descending = $Descending
+        OutputFilePrefix = $OutputFilePrefix
+        Value = $Value
         Version=$Version
         RawContent=$RawContent
         AbsoluteUri=$AbsoluteUri
@@ -136,6 +142,12 @@ The First parameter specifies that Graph should only return a specific number of
 
 .PARAMETER Skip
 Skip specifies that Graph should not return the first N results in the HTTP response, i.e. that it should "discard" them. Graph determines the results to throw away after sorting them according to the order Graph defaults to or is specified by this command through the OrderBy parameter. This parameter can be used in conjunction with this First parameter to page through results -- if 20 results were already returned by one or more previous invocations of this command, then by specifying 20 for Skip in the next invocation, Graph will skip past the previously returned results and return the next "page" of results with a page size specified by First.
+
+.PARAMETER Value
+The Value parameter may be used when the result is itself metadata describing some data, such as an image. To obtain the actual data, rather than the metadata, specify Value. This is particularly useful for obtaining pictures for instance, e.g. me/photo.
+
+.PARAMETER OutputFilePrefix
+The OutputFilePrefix parameter specifies that rather than emitting the results to the PowerShell pipeline, each result should be written to a file name prefixed with the value of the OutputFilePrefix. The parameter value may be a path to a directory, or simply a name with no path separator. If there is more than one item in the result, the base file name for that result will end with a unique integer identifier within the result set. The file extension will be 'json' unless the result is of another content type, in which case the command will attempt to determine the extension from the content type returned in the HTTP response. If the content type cannot be determined, then the file extension will be '.dat'.
 
 .PARAMETER Query
 The Query parameter specifies the URI query parameter of the REST request made by the command to Graph. Because the URI's query parameter is affected by the Select, ODataFilter, OrderBy, Search, and Expand options, the command's Query parameter may not be specified of any those parameters are specified. This parameter is most useful for advanced scenarios where the other command parameters are unable to express valid Graph protocol use of the URI query parameter.

--- a/src/cmdlets/common/GraphOutputFile.ps1
+++ b/src/cmdlets/common/GraphOutputFile.ps1
@@ -1,0 +1,80 @@
+# Copyright 2019, Adam Edwards
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ScriptClass GraphOutputFile {
+    $baseName = $null
+    $fileContent = $null
+    $contentTypeData = $null
+
+    function __initialize($baseName, $fileContent, $contentTypeData) {
+        $this.baseName = $baseName
+        $this.fileContent = $fileContent
+        $this.contentTypeData = $contentTypeData
+    }
+
+    function Save {
+        $typeData = __GetTypeData
+
+        $destinationPath = "$baseName.$($typeData.Extension)"
+
+        write-verbose "Saving result to file path = '$destinationPath'; isBinary=$($typeData.IsBinary); extension = '$($typeData.extension)'; encoding = '$($typeData.encoding)'"
+
+        if ( $typeData.IsBinary ) {
+            __SaveBinary $destinationPath
+        } else {
+            __SaveText $destinationPath $typeData.encoding
+        }
+
+        get-item $destinationPath
+    }
+
+    function __GetTypeData {
+        $isBinary = $false
+        $extension = '.dat'
+        $encoding = 'Default'
+
+        if ( $this.contentTypeData['application/json'] ) {
+            $isBinary = $false
+            $extension = 'json'
+            $charset = $this.contentTypeData['charset']
+            if ( $charset -eq 'utf-8') {
+                $encoding = 'UTF8'
+            } else {
+                $encodig = 'Default'
+            }
+        } elseif ( $this.contentTypeData['image/jpeg'] ) {
+            $isBinary = $true
+            $extension = 'jpg'
+            $encoding = 'Byte'
+        }
+
+        $result = @{Extension = $extension;IsBinary = $isBinary; Encoding = $encoding}
+
+        [PSCustomObject] $result
+    }
+
+    function __SaveBinary($path) {
+        $encodingArgument = if ( $PSVersionTable.PSEdition -eq 'Desktop' ) {
+            @{Encoding='Byte'}
+        } else {
+            @{AsByteStream=(. {param([switch] $switchVal) $switchValval} -switchVal)}
+        }
+
+        set-content -path $path -value $this.fileContent @encodingArgument
+    }
+
+    function __SaveText($path, $encoding) {
+        set-content -path $path -value $this.fileContent -Encoding $encoding
+    }
+}

--- a/src/cmdlets/common/ItemResultHelper.ps1
+++ b/src/cmdlets/common/ItemResultHelper.ps1
@@ -29,3 +29,11 @@ function __GetResultVariable( $customVariableName ) {
         }
     }
 }
+
+function  __ToResponseWithObject($object, $response) {
+    [PSCustomObject] @{
+        Data = $object
+        ResponseContent = $response.RestResponse.Content
+        ResponseRawContent = $response.RestResponse.RawContent
+    }
+}

--- a/src/common/ScopeHelper.ps1
+++ b/src/common/ScopeHelper.ps1
@@ -18,6 +18,7 @@
 ScriptClass ScopeHelper {
     static {
         const GraphApplicationId 00000003-0000-0000-c000-000000000000
+        const DefaultScopeQualifier ([Uri] 'https://graph.microsoft.com')
         $graphSP = $null
         $permissionsByIds = $null
         $appOnlyPermissionsByName = $null
@@ -207,6 +208,20 @@ ScriptClass ScopeHelper {
             }
 
             $permission.value
+        }
+
+        function QualifyScopes([string[]] $scopes, [Uri] $resourceUri) {
+            if ( ! $resourceUri -or ( $resourceUri -eq $this.DefaultScopeQualifier ) ) {
+                $scopes
+            } else {
+                foreach ( $scope in $scopes )  {
+                    if ( ( [Uri] $scope ).IsAbsoluteUri ) {
+                        [string] $scope
+                    } else {
+                        [string] [Uri]::new($resourceUri, $scope)
+                    }
+                }
+            }
         }
 
         function __IsPermissionType($permissionId, $type) {

--- a/src/graphservice/GraphEndpoint.ps1
+++ b/src/graphservice/GraphEndpoint.ps1
@@ -51,17 +51,17 @@ ScriptClass GraphEndpoint {
             [GraphCloud]::ChinaCloud = @{
                 Authentication='https://login.chinacloudapi.cn'
                 Graph='https://microsoftgraph.chinacloudapi.cn'
-                AuthProtocol=[GraphAuthProtocol]::v1
+                AuthProtocol=[GraphAuthProtocol]::v2
             }
             [GraphCloud]::GermanyCloud = @{
                 Authentication='https://login.microsoftonline.de'
                 Graph='https://graph.microsoft.de'
-                AuthProtocol=[GraphAuthProtocol]::v1
+                AuthProtocol=[GraphAuthProtocol]::v2
             }
             [GraphCloud]::USGovernmentCloud = @{
                 Authentication='https://login.microsoftonline.us'
                 Graph='https://graph.microsoft.us'
-                AuthProtocol=[GraphAuthProtocol]::v1
+                AuthProtocol=[GraphAuthProtocol]::v2
             }
         }
 


### PR DESCRIPTION
### Description
Adds ability to retrieve value for scenarios like `me/photo` and fixes v2 auth with national clouds

### New dependencies

None.

### New features

* Value parameter for `Invoke-GraphRequest`, `Get-GraphItem` to make `$value` requests
* `OutputFilePrefix` parameter for `Invoke-GraphRequest`, `Get-GraphItem` for sending output to the file system
* `IncludeFullResponse` parameter for `Invoke-GraphRequest` to allow retrieval of the full response object in the output

### Fixed defects

* Fixed broken v2 auth for national clouds due to incorrectly qualified scopes

### Checklist

- [x] All project tests pass successfully