### PR TITLE
Client request ID and user agent support

### DIFF
--- a/AutoGraphPS-SDK.psd1
+++ b/AutoGraphPS-SDK.psd1
@@ -209,15 +209,15 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
-# AutoGraphPS-SDK 0.13.0 Release Notes
+## AutoGraphPS-SDK 0.13.0 Release Notes
 
 This release adds features for additional API request customization and includes fixes for defects
 related to AAD application management commands.
 
-## New dependencies
+### New dependencies
 None.
 
-## Breaking changes
+### Breaking changes
 
 * The `Set-GraphApplicationConsent` parameter `AppOnlyPermissions` has been changed to `ApplicationPermissions` to for
   consistency with the changes made in `0.11.1` made to other commands with the same parameter. This change was intended
@@ -225,7 +225,7 @@ None.
 * The `AllApplicationPermissions` parameter of `Remove-GraphApplicationConsent` is renamed `AllPermissions`.
 * The `AllTenantUsers` parameter of `Remove-GraphApplicationConsent` is renamed `ConsentForAllUsers`.
 
-## New features
+### New features
 
 * By default, any request to Graph sets the `client-request-id` header with a unique GUID per request
 * The `Get-GraphItem` and `Invoke-GraphRequest` commands support the following new parameters:
@@ -241,7 +241,7 @@ None.
 * `Remove-GraphApplicationConsent` now accepts pipeline input from output of `Get-GraphApplicationConsent` via
    `$ConsentGrant` parameter.
 
-## Fixed defects
+### Fixed defects
 
 * `Remove-GraphItem` unusable without explicitly specifying `Cloud` parameter because of parameter binding issue in the default case.
 * `New-GraphApplication` did not honor the `ConsentAllUsers` parameter and wrote an error about an undefined variable to

--- a/AutoGraphPS-SDK.psd1
+++ b/AutoGraphPS-SDK.psd1
@@ -12,7 +12,7 @@
 RootModule = 'autographps-sdk.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.12.0'
+ModuleVersion = '0.13.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -209,9 +209,9 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
-# AutoGraphPS-SDK 0.12.0 Release Notes
+# AutoGraphPS-SDK 0.13.0 Release Notes
 
-This release fixes defects introduced by the previous `0.11.1` release and includes some minor feature updates.
+This release adds features for additional API request customization.
 
 ## New dependencies
 None.
@@ -221,24 +221,16 @@ None.
 
 ## New features
 
-* Added the `ReplyUrl` alias to the `AppRedirectUri` parameter of `Get-GraphToken`, `Connect-Graph` and `New-GraphConnection`
-* `Get-GraphConnectionInfo` now includes a connection id guid property in its output to identify each unique connection
+* By default, any request to Graph sets the `client-request-id` header with a unique GUID per request
+* The `Get-GraphItem` and `Invoke-GraphRequest` commands support the following new parameters:
+     * `ClientRequestId`: overrides the auto-generated value of the `client-request-id` header with the
+       specified GUID value
+     * `NoClientRequestId`: switch overrides the behavior of supplying an auto-generated `client-request-id` header
+       and instead does not specify the header at all
 
 ## Fixed defects
 
-* `Test-Graph` command regression prevented targeting clouds other than `Public`
-* `Get-GraphToken`, `Connect-Graph` and `New-GraphConnection` regressions caused certain parameter sets to require all parameters
-* Fix race condition with `Connect-Graph` due to MSAL changes with integrated token cache: `Connect-Graph` created
-  a new token, which was immediately invalidated, requiring a reconnect when used with a command.
-* Fix error output from `Get-GraphToken` due to missing `GraphResourceUri` parameter, which also blocked alternate resource uri functionality
-
 ### Miscellaneous implementation notes
-
-The most involved fix was to address a defect introduced when the `MSAL` library version was updated to `4.4.0`. Prior to this release, token caches were maintained independently from the `PublicClientApplication` or `ConfidentialClientApplication` authentication context.
-
-With `MSAL` `4.4.0`, token caches were part of the authentication context. When `4.4.0` was integrated into `AutoGraphPS-SDK`, this change was accounted for, but there was still an assumption that the authentication context could be shared across the `AutoGraphPS-SDK` notion of `Connection` without the cache being affected by the sharing. Since cache had become part of the auth context, sharing the auth context as `AutoGraphPS-SDK` had always done for a given connection meant sharing caches; this introduced race conditions where a token could be added to a cache only to have it immediately removed by an operation that was assumed to be independent of that cache but wasn't. The result was that users would someitmes be requested to sign-in again immediately after a sign-in prompted by `Connect-Graph` or any command that affected connection management.
-
-The fix was to ensure each connection used a separate authentication context by associating each auth context with a connection in a store of auth contexts. A better fix may be to remove the store of auth contexts altogether, and make the auth context part of the connection itself, or at least simplify the lookup logic to use only the connection id.
 
 '@
 

--- a/AutoGraphPS-SDK.psd1
+++ b/AutoGraphPS-SDK.psd1
@@ -219,9 +219,11 @@ None.
 
 ## Breaking changes
 
-The `Set-GraphApplicationConsent` parameter `AppOnlyPermissions` has been changed to `ApplicationPermissions` to for
-consistency with the changes made in `0.11.1` made to other commands with the same parameter. This change was intended
-to be part of the `0.11.1` release but was missed.
+* The `Set-GraphApplicationConsent` parameter `AppOnlyPermissions` has been changed to `ApplicationPermissions` to for
+  consistency with the changes made in `0.11.1` made to other commands with the same parameter. This change was intended
+  to be part of the `0.11.1` release but was missed.
+* The `AllApplicationPermissions` parameter of `Remove-GraphApplicationConsent` is renamed `AllPermissions`.
+* The `AllTenantUsers` parameter of `Remove-GraphApplicationConsent` is renamed `ConsentForAllUsers`.
 
 ## New features
 
@@ -236,6 +238,8 @@ to be part of the `0.11.1` release but was missed.
    used by all requests made through the resulting connection.
 * As noted in the breaking changes section, the `ApplicationPermissions` parameter has replaced `AppOnlyPermissions` in
   `Set-GraphApplicationConsent`.
+* `Remove-GraphApplicationConsent` now accepts pipeline input from output of `Get-GraphApplicationConsent` via
+   `$ConsentGrant` parameter.
 
 ## Fixed defects
 

--- a/AutoGraphPS-SDK.psd1
+++ b/AutoGraphPS-SDK.psd1
@@ -217,7 +217,10 @@ This release adds features for additional API request customization.
 None.
 
 ## Breaking changes
-None.
+
+The `Set-GraphApplicationConsent` parameter `AppOnlyPermissions` has been changed to `ApplicationPermissions` to for
+consistency with the changes made in `0.11.1` made to other commands with the same parameter. This change was intended
+to be part of the `0.11.1` release but was missed.
 
 ## New features
 
@@ -227,13 +230,20 @@ None.
        specified GUID value
      * `NoClientRequestId`: switch overrides the behavior of supplying an auto-generated `client-request-id` header
        and instead does not specify the header at all
-* `UserAgent` parameter added to `New-GraphConnection` and `Connect-Graph`: By default, AutoGraphPS specifies a particular
+* `UserAgent` parameter now added to `New-GraphConnection` and `Connect-Graph`: By default, AutoGraphPS specifies a particular
    user agent when sending requests. The `UserAgent` parameter allows these commands to set a specific user agent string
    used by all requests made through the resulting connection.
+* As noted in the breaking changes section, the `ApplicationPermissions` parameter has replaced `AppOnlyPermissions` in
+  `Set-GraphApplicationConsent`.
 
 ## Fixed defects
 
-### Miscellaneous implementation notes
+* `New-GraphApplication` did not honor the `ConsentAllUsers` parameter and wrote an error about an undefined variable to
+  the error stream. The incorret variable usage has been corrected and the parameter is now honored.
+* `Register-GraphApplication`'s consent functionality explicitly or silently failed due to regression from breaking changes
+  to other parts of the module in version 0.11.1. The command has been fixed to be compatible with the changes.
+* `Get-GraphApplication` output extra words / characters in the `StartTime` field -- this formatting issue is now fixed.
+* `Set-GraphAllicationConsent` was ignoring `ConsentAllUsers` and was not adding `AllPrincipals` consent grants -- this is fixed.
 
 '@
 

--- a/AutoGraphPS-SDK.psd1
+++ b/AutoGraphPS-SDK.psd1
@@ -211,7 +211,8 @@ PrivateData = @{
         ReleaseNotes = @'
 # AutoGraphPS-SDK 0.13.0 Release Notes
 
-This release adds features for additional API request customization.
+This release adds features for additional API request customization and includes fixes for defects
+related to AAD application management commands.
 
 ## New dependencies
 None.
@@ -238,12 +239,16 @@ to be part of the `0.11.1` release but was missed.
 
 ## Fixed defects
 
+* `Remove-GraphItem` unusable without explicitly specifying `Cloud` parameter because of parameter binding issue in the default case.
 * `New-GraphApplication` did not honor the `ConsentAllUsers` parameter and wrote an error about an undefined variable to
   the error stream. The incorret variable usage has been corrected and the parameter is now honored.
 * `Register-GraphApplication`'s consent functionality explicitly or silently failed due to regression from breaking changes
   to other parts of the module in version 0.11.1. The command has been fixed to be compatible with the changes.
 * `Get-GraphApplication` output extra words / characters in the `StartTime` field -- this formatting issue is now fixed.
 * `Set-GraphAllicationConsent` was ignoring `ConsentAllUsers` and was not adding `AllPrincipals` consent grants -- this is fixed.
+* `Remove-GraphConsent` syntax error due to reference to non-existent parameter, broken *All Users* consent removal
+* `New-GraphApplication` adds minimal required permissions to the application object when permissions are not specified --
+   only delegated permissions are added for public client apps, and only offline_access instead of `User.Read`.
 
 '@
 

--- a/AutoGraphPS-SDK.psd1
+++ b/AutoGraphPS-SDK.psd1
@@ -227,6 +227,9 @@ None.
        specified GUID value
      * `NoClientRequestId`: switch overrides the behavior of supplying an auto-generated `client-request-id` header
        and instead does not specify the header at all
+* `UserAgent` parameter added to `New-GraphConnection` and `Connect-Graph`: By default, AutoGraphPS specifies a particular
+   user agent when sending requests. The `UserAgent` parameter allows these commands to set a specific user agent string
+   used by all requests made through the resulting connection.
 
 ## Fixed defects
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,8 @@
 * Add equivalent of -Token option to new-graphconnection and connect-graph -- this sets token from external source
 * Make verbose output more readable
 * Document strange splatting behavior with noteproperty
-* Rename New-GraphApplicationCertificate to Set-GraphApplicationCertificate?
+* New-GraphApplicationCertificate with -noupload option
+* Set-GraphApplicationCertificate to set to an existing certificate
 
 
 * Add $ref?

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,8 +3,6 @@
 ## To-do items -- prioritized
 
 * Add more command help
-* Add client-side correlationid
-* Make token caches per app-per cloud.
 * Add useragent to connection commands
 * Add view to get-grapherror
 * Add throttling
@@ -356,6 +354,7 @@
 * Add support for test endpoints by allowing alternate resource for endpoint uri
 * Make comments start at beginning of command
 * Make Get-GraphToken take all params from new-graphconnection and get-graphconnection
+* Add client-side correlationid
 
 ### Postponed
 
@@ -381,6 +380,7 @@
 * Make public graph items have id instead of name
 * switch to 3 columns by default -- remove class
 * Move some data to info, possibly show rwx
+* Make token caches per app-per cloud.
 
 #### Stdposh improvements
 

--- a/src/REST/GraphRequest.ps1
+++ b/src/REST/GraphRequest.ps1
@@ -114,7 +114,7 @@ ScriptClass GraphRequest {
     function __InvokeRequest($verb, $uri, $query) {
         $uriPath = __UriWithQuery $uri $query
         $uri = new-object Uri $uriPath
-        $restRequest = new-so RESTRequest $uri $verb $this.headers $this.body
+        $restRequest = new-so RESTRequest $uri $verb $this.headers $this.body $this.Connection.UserAgent
         $restRequest |=> Invoke
     }
 

--- a/src/REST/RESTRequest.ps1
+++ b/src/REST/RESTRequest.ps1
@@ -55,8 +55,8 @@ ScriptClass RESTRequest {
             $body | convertto-json -depth 6
         }
 
-        $this.userAgent = if ( $userAgent -ne $null ) {
-            $this.userAgent = $userAgent
+        $this.userAgent = if ( $userAgent ) {
+            $userAgent
         } else {
             $this.scriptclass.PoshGraphUserAgent
         }

--- a/src/client/GraphConnection.ps1
+++ b/src/client/GraphConnection.ps1
@@ -28,13 +28,15 @@ ScriptClass GraphConnection {
     $Connected = $false
     $Status = [GraphConnectionStatus]::Online
     $NoBrowserUI = $false
+    $UserAgent = $null
 
-    function __initialize([PSCustomObject] $graphEndpoint, [PSCustomObject] $Identity, [Object[]]$Scopes, $noBrowserUI = $false) {
+    function __initialize([PSCustomObject] $graphEndpoint, [PSCustomObject] $Identity, [Object[]]$Scopes, $noBrowserUI = $false, $userAgent = $null) {
         $this.Id = new-guid
         $this.GraphEndpoint = $graphEndpoint
         $this.Identity = $Identity
         $this.Connected = $false
         $this.Status = [GraphConnectionStatus]::Online
+        $this.UserAgent = $userAgent
 
         $isRemotePSSession = (get-variable PSSenderInfo -erroraction ignore) -ne $null
         write-verbose ("Browser supported: {0}, NoBrowserUISpecified {1}, IsRemotePSSession: {2}" -f $::.Application.SupportsBrowserSignin, $noBrowserUI, $isRemotePSSession)
@@ -102,14 +104,14 @@ ScriptClass GraphConnection {
     }
 
     static {
-        function NewSimpleConnection([string] $graphType = 'MSGraph', [string] $cloud = 'Public', [String[]] $ScopeNames, $anonymous = $false, $tenantName = $null, $authProtocol = $null ) {
+        function NewSimpleConnection([string] $graphType = 'MSGraph', [string] $cloud = 'Public', [String[]] $ScopeNames, $anonymous = $false, $tenantName = $null, $authProtocol = $null, $userAgent = $null ) {
             $endpoint = new-so GraphEndpoint $cloud $graphType $null $null $authProtocol
             $app = new-so GraphApplication $::.Application.DefaultAppId
             $identity = if ( ! $anonymous ) {
                 new-so GraphIdentity $app $endpoint $tenantName
             }
 
-            new-so GraphConnection $endpoint $identity $ScopeNames
+            new-so GraphConnection $endpoint $identity $ScopeNames $false $userAgent
         }
 
         function ToConnectionInfo([PSCustomObject] $connection) {

--- a/src/cmdlets/Connect-Graph.ps1
+++ b/src/cmdlets/Connect-Graph.ps1
@@ -112,6 +112,8 @@ function Connect-Graph {
         [parameter(parametersetname='customendpoint')]
         [switch] $AADGraph,
 
+        [string] $UserAgent = $null,
+
         [parameter(parametersetname='reconnect', mandatory=$true)]
         [Switch] $Reconnect,
 

--- a/src/cmdlets/Get-GraphItem.ps1
+++ b/src/cmdlets/Get-GraphItem.ps1
@@ -72,6 +72,9 @@ Specifies optional HTTP headers to include in the request to Graph, which some p
 .PARAMETER Version
 Specifies the Graph API version that this command should target when making Graph requests. When not specified, the API version of the current Graph is used, which is v1.0 for the default Graph.
 
+.PARAMETER ClientRequestId
+Specifies the client request in the form of a GUID id that should be passed in the 'client-request-id' request header to the Graph API. This can be used to correlate verbose output regarding the request made by this command with request logs accessible to the operator of the Graph API service. Such correlation speeds up diagnosis of errors in service support scenarios. By default, this command automatically generates a request id and sends it in the header and also logs it in the command's verbose output, so this parameter does not need to be specified unless there is a particular reason to customize the id, such as using an id generated from another tool or API as a prerequisite for issuing this command that makes it easy to correlate the request from this command with that tool output for troubleshooting and log analysis. It is possible to prevent the generation of a client request id altogether by specifying the NoClientRequestId parameter.
+
 .PARAMETER Connection
 Specifies a Connection object returned by the New-GraphConnection command whose Graph endpoint will be accessed when making Graph requests with this command.
 
@@ -89,6 +92,9 @@ This parameter specifies that the command should return results exactly in the f
 
 .PARAMETER AADGraph
 This parameter specifies that instead of accessing Microsoft Graph, the command should make requests against Azure Active Directory Graph (AAD Graph). Note that most functionality of this command and other commands in the module is not compatible with AAD Graph; this parameter may be deprecated in the future.
+
+.PARAMETER NoClientRequestId
+This parameter suppresses the automatic generation and submission of the 'client-request-id' header in the request used for troubleshooting with service-side request logs. This parameter is included only to enable complete control over the protocol as there would be very few use cases for not sending the request id.
 
 .OUTPUTS
 The command returns the content of the HTTP response from the Graph endpoint. The result will depend on the documented response of GET requests for the Graph URI. The results are formatted as either deserialized PowerShell objects, or, if the RawContent parameter is also sp ecified, the literal content of the HTTP response. Because Graph responds to requests with JSON except in cases where content types such as images or other media are requested, use of the RawContent parameter will usually result in JSON output.
@@ -172,6 +178,8 @@ function Get-GraphItem {
 
         [String] $Version = $null,
 
+        [Guid] $ClientRequestId,
+
         [parameter(parametersetname='ExistingConnection', mandatory=$true)]
         [PSCustomObject] $Connection = $null,
 
@@ -188,6 +196,8 @@ function Get-GraphItem {
 
         [parameter(parametersetname='AADGraphNewConnection', mandatory=$true)]
         [switch] $AADGraph,
+
+        [switch] $NoClientRequestId,
 
         [string] $ResultVariable = $null
     )
@@ -209,6 +219,7 @@ function Get-GraphItem {
         RawContent=$RawContent
         AbsoluteUri=$AbsoluteUri
         Headers=$Headers
+        NoClientRequestId=$NoClientRequestId
         First=$pscmdlet.pagingparameters.first
         Skip=$pscmdlet.pagingparameters.skip
         IncludeTotalCount=$pscmdlet.pagingparameters.includetotalcount
@@ -216,6 +227,10 @@ function Get-GraphItem {
 
     if ( $Cloud ) {
         $requestArguments['Cloud'] = $Cloud
+    }
+
+    if ( $ClientRequestId ) {
+        $requestArguments['ClientRequestId'] = $ClientRequestId
     }
 
     if ( $AADGraph.ispresent ) {

--- a/src/cmdlets/New-GraphApplication.ps1
+++ b/src/cmdlets/New-GraphApplication.ps1
@@ -53,7 +53,7 @@ function New-GraphApplication {
         [parameter(parametersetname='confidentialappexistingcert')]
         [switch] $NoCredential,
 
-        [switch] $ConsentAllUsers,
+        [switch] $ConsentForAllUsers,
 
         [switch] $NoConsent,
 
@@ -92,8 +92,8 @@ function New-GraphApplication {
     }
 
     if ( $SkipTenantRegistration.IsPresent ) {
-        if ( $UserIdToConsent -or $ConsentAllUsers.IsPresent ) {
-            throw [ArgumentException]::new("'SkipTenantRegistration' may not be specified if 'UserIdToConsent' or 'ConsentAllUsers' is specified")
+        if ( $UserIdToConsent -or $ConsentForAllUsers.IsPresent ) {
+            throw [ArgumentException]::new("'SkipTenantRegistration' may not be specified if 'UserIdToConsent' or 'ConsentForAllUsers' is specified")
         }
     }
     $commandContext = new-so CommandContext $Connection $Version $null $null $::.ApplicationAPI.DefaultApplicationApiVersion
@@ -138,7 +138,7 @@ function New-GraphApplication {
     }
 
     if ( ! $SkipTenantRegistration.IsPresent ) {
-        $newAppRegistration |=> Register $true (! $NoConsent.IsPresent) $ConsentAllUsers.IsPresent $UserIdToConsent $DelegatedUserPermissions $ApplicationPermissions | out-null
+        $newAppRegistration |=> Register $true (! $NoConsent.IsPresent) $ConsentForAllUsers.IsPresent $UserIdToConsent $DelegatedUserPermissions $ApplicationPermissions | out-null
     }
 
     $newApp

--- a/src/cmdlets/New-GraphApplication.ps1
+++ b/src/cmdlets/New-GraphApplication.ps1
@@ -92,8 +92,8 @@ function New-GraphApplication {
     }
 
     if ( $SkipTenantRegistration.IsPresent ) {
-        if ( $UserIdToConsent -or $ConsentForTenant.IsPresent ) {
-            throw [ArgumentException]::new("'SkipTenantRegistration' may not be specified if 'UserIdToConsent' or 'ConsentForTenant' is specified")
+        if ( $UserIdToConsent -or $ConsentAllUsers.IsPresent ) {
+            throw [ArgumentException]::new("'SkipTenantRegistration' may not be specified if 'UserIdToConsent' or 'ConsentAllUsers' is specified")
         }
     }
     $commandContext = new-so CommandContext $Connection $Version $null $null $::.ApplicationAPI.DefaultApplicationApiVersion

--- a/src/cmdlets/New-GraphApplication.ps1
+++ b/src/cmdlets/New-GraphApplication.ps1
@@ -138,17 +138,7 @@ function New-GraphApplication {
     }
 
     if ( ! $SkipTenantRegistration.IsPresent ) {
-        $delegatedPermissionsToConsent = if ( ! $Confidential.IsPresent -and ! $ApplicationPermissions -and ! $DelegatedUserPermissions ) {
-            # If at least one delegated permission is not consented, it seems the STS will not grant access when
-            # a request is made for the token, so for apps we know to be accessed only as public client apps we
-            # consent to offline_access
-            write-verbose "No delegated permissions specified for public application, will add 'offline_access' for consent"
-            @('offline_access')
-            $DelegatedUserPermissions
-        } else {
-            $DelegatedUserPermissions
-        }
-        $newAppRegistration |=> Register $true (! $NoConsent.IsPresent) $ConsentAllUsers.IsPresent $UserIdToConsent $delegatedPermissionsToConsent $ApplicationPermissions | out-null
+        $newAppRegistration |=> Register $true (! $NoConsent.IsPresent) $ConsentAllUsers.IsPresent $UserIdToConsent $DelegatedUserPermissions $ApplicationPermissions | out-null
     }
 
     $newApp

--- a/src/cmdlets/New-GraphApplication.ps1
+++ b/src/cmdlets/New-GraphApplication.ps1
@@ -138,7 +138,17 @@ function New-GraphApplication {
     }
 
     if ( ! $SkipTenantRegistration.IsPresent ) {
-        $newAppRegistration |=> Register $true (! $NoConsent.IsPresent) $ConsentAllUsers.IsPresent $UserIdToConsent $DelegatedUserPermissions $ApplicationPermissions | out-null
+        $delegatedPermissionsToConsent = if ( ! $Confidential.IsPresent -and ! $ApplicationPermissions -and ! $DelegatedUserPermissions ) {
+            # If at least one delegated permission is not consented, it seems the STS will not grant access when
+            # a request is made for the token, so for apps we know to be accessed only as public client apps we
+            # consent to offline_access
+            write-verbose "No delegated permissions specified for public application, will add 'offline_access' for consent"
+            @('offline_access')
+            $DelegatedUserPermissions
+        } else {
+            $DelegatedUserPermissions
+        }
+        $newAppRegistration |=> Register $true (! $NoConsent.IsPresent) $ConsentAllUsers.IsPresent $UserIdToConsent $delegatedPermissionsToConsent $ApplicationPermissions | out-null
     }
 
     $newApp

--- a/src/cmdlets/New-GraphConnection.ps1
+++ b/src/cmdlets/New-GraphConnection.ps1
@@ -108,7 +108,9 @@ function New-GraphConnection {
 
         [parameter(parametersetname='aadgraph', mandatory=$true)]
         [parameter(parametersetname='customendpoint')]
-        [switch] $AADGraph
+        [switch] $AADGraph,
+
+        [String] $UserAgent = $null
     )
 
     begin {
@@ -146,7 +148,7 @@ function New-GraphConnection {
 
         if ( $GraphEndpointUri -eq $null -and $AuthenticationEndpointUri -eq $null -and $specifiedAuthProtocol -and $appId -eq $null ) {
             write-verbose 'Simple connection specified with no custom uri, auth protocol, or app id'
-            $::.GraphConnection |=> NewSimpleConnection $graphType $validatedCloud $specifiedScopes $false $TenantId $computedAuthProtocol
+            $::.GraphConnection |=> NewSimpleConnection $graphType $validatedCloud $specifiedScopes $false $TenantId $computedAuthProtocol -useragent $UserAgent
         } else {
             $graphEndpoint = if ( $GraphEndpointUri -eq $null ) {
                 write-verbose 'Custom endpoint data required, no graph endpoint URI was specified, using URI based on cloud'
@@ -196,7 +198,7 @@ function New-GraphConnection {
 
             $app = new-so GraphApplication $newAppId $AppRedirectUri $appSecret $NoninteractiveAppOnlyAuth.IsPresent
             $identity = new-so GraphIdentity $app $graphEndpoint $adjustedTenantId
-            new-so GraphConnection $graphEndpoint $identity $specifiedScopes $NoBrowserSigninUI.IsPresent
+            new-so GraphConnection $graphEndpoint $identity $specifiedScopes $NoBrowserSigninUI.IsPresent $userAgent
         }
     }
 }

--- a/src/cmdlets/Remove-GraphApplicationConsent.ps1
+++ b/src/cmdlets/Remove-GraphApplicationConsent.ps1
@@ -48,7 +48,7 @@ function Remove-GraphApplicationConsent {
     process {
         Enable-ScriptClassVerbosePreference
 
-        $isAppOnly = $AllApplicationPermissions.IsPresent -or $ApplicationPermissions.length -gt 0
+        $isAppOnly = $AllApplicationPermissions.IsPresent -or ($ApplicationPermissions -and $ApplicationPermissions.length -gt 0)
 
         $commandContext = new-so CommandContext $Connection $Version $null $null $::.ApplicationAPI.DefaultApplicationApiVersion
         $appAPI = new-so ApplicationAPI $commandContext.connection $commandContext.version
@@ -59,13 +59,13 @@ function Remove-GraphApplicationConsent {
         $appFilter = "clientId eq '$appSPId'"
         $filterClauses = @($appFilter)
 
-        if ( ! $AllTenantUsers.IsPresent ) {
-            $grantFilter = if ( $ConsentForTenant.IsPresent ) {
-                "consentType eq 'AllPrincipals'"
-            } elseif ( $Principal ) {
-                "consentType eq 'Principal' and principalId eq '$Principal'"
-            }
+        $grantFilter = if ( $AllTenantUsers.IsPresent ) {
+            "consentType eq 'AllPrincipals'"
+        } elseif ( $Principal ) {
+            "consentType eq 'Principal' and principalId eq '$Principal'"
+        }
 
+        if ( $grantFilter ) {
             $filterClauses += $grantFilter
         }
 

--- a/src/cmdlets/Remove-GraphApplicationConsent.ps1
+++ b/src/cmdlets/Remove-GraphApplicationConsent.ps1
@@ -22,6 +22,9 @@ function Remove-GraphApplicationConsent {
         [parameter(position=0, mandatory=$true)]
         [Guid[]] $AppId,
 
+        [parameter(parametersetname='consentgrant', valuefrompipeline=$true, mandatory=$true)]
+        $ConsentGrant,
+
         [parameter(position=1,parametersetname='application', mandatory=$true)]
         [string[]] $ApplicationPermissions,
 
@@ -30,25 +33,48 @@ function Remove-GraphApplicationConsent {
         [string[]] $DelegatedUserPermissions,
 
         [parameter(parametersetname='delegatedallusers', mandatory=$true)]
-        [switch] $AllTenantUsers,
+        [switch] $ConsentForAllUsers,
 
         [parameter(parametersetname='delegated')]
         $Principal,
 
-        [parameter(parametersetname='allapppermissions', mandatory=$true)]
-        [switch] $AllApplicationPermissions,
+        [parameter(parametersetname='allpermissions', mandatory=$true)]
+        [switch] $AllPermissions,
 
         $Connection,
 
         $Version
     )
 
-    begin {}
+    begin {
+        # This is only for the AllPermissions case and is required to delete multiple oauth2Grants
+        # (i.e. delegated permission consents) being passed to the pipeline. This is due to the fact
+        # the graph API records multiple permissions per oauth2Grant object, but Get-GraphApplicationConsent
+        # returns exactly one custom object per permission. That means that more than one of the objects
+        # may reference the same oauth2Grant object. We use this table to keep track of the objects passed
+        # to the pipeline so that we can skip any object from a previous permission that has already been
+        # deleted.
+        $processedOAuth2Grants = @{}
+    }
 
     process {
         Enable-ScriptClassVerbosePreference
 
-        $isAppOnly = $AllApplicationPermissions.IsPresent -or ($ApplicationPermissions -and $ApplicationPermissions.length -gt 0)
+        $consentObject = $null
+        $consentGrantType = if ( $ConsentGrant ) {
+            if ( ! ( $ConsentGrant | gm GraphResource -erroraction ignore ) ) {
+                throw "The ConsentGrant parameter was invalid -- it did not have a member named 'GraphResource'"
+            }
+            $consentObject = $ConsentGrant.GraphResource
+            if ( $processedOauth2Grants[$consentObject.id] ) {
+                return
+            }
+            $processedOauth2Grants[$consentObject.id] = $consentObject
+
+            $ConsentGrant.PermissionType
+        }
+
+        $isAppOnly = ($consentGrantType -eq 'Application') -or ( $ApplicationPermissions -and ( $ApplicationPermissions.length -gt 0 ) )
 
         $commandContext = new-so CommandContext $Connection $Version $null $null $::.ApplicationAPI.DefaultApplicationApiVersion
         $appAPI = new-so ApplicationAPI $commandContext.connection $commandContext.version
@@ -59,7 +85,7 @@ function Remove-GraphApplicationConsent {
         $appFilter = "clientId eq '$appSPId'"
         $filterClauses = @($appFilter)
 
-        $grantFilter = if ( $AllTenantUsers.IsPresent ) {
+        $grantFilter = if ( $ConsentForAllUsers.IsPresent ) {
             "consentType eq 'AllPrincipals'"
         } elseif ( $Principal ) {
             "consentType eq 'Principal' and principalId eq '$Principal'"
@@ -69,38 +95,55 @@ function Remove-GraphApplicationConsent {
             $filterClauses += $grantFilter
         }
 
-        $filter = $filterClauses -join ' and '
+        $filterArgument = if ( ! $consentObject ) {
+            @{ODataFilter = ($filterClauses -join ' and ')}
+        } else {
+            @{}
+        }
 
-        if ( ! $isAppOnly ) {
-            $grants = $commandContext |=> InvokeRequest -uri oauth2PermissionGrants -RESTmethod GET -ODataFilter $filter
+        # For oauth2 grants, we either delete the entire grant (in the case of AllPermissions)
+        # or edit an existing matching grant to remove a targeted permission => principal assigment.
+        if ( ! $isAppOnly -or $AllPermissions.IsPresent ) {
+            $grants = if ( ! $consentObject ) {
+                $commandContext |=> InvokeRequest -uri oauth2PermissionGrants -RESTmethod GET @filterArgument
+            } else {
+                @($consentObject)
+            }
 
-            if ( $grants -and ( $grants | gm id ) ) {
+            if ( $grants -and ( $grants | gm id -erroraction ignore ) ) {
                 $grants | foreach {
                     if ( ! $DelegatedUserPermissions ) {
-                        $commandContext |=> InvokeRequest -uri "/oauth2PermissionGrants/$($_.id)" -RESTmethod DELETE | out-null
+                        $commandContext |=> InvokeRequest -uri "/oauth2PermissionGrants/$($_.id)" -RESTMethod DELETE | out-null
                     } else {
                         $reducedPermissions = $appAPI |=> GetReducedPermissionsString $_.scope $DelegatedUserPermissions
                         if ( $reducedPermissions ) {
                             $updatedScope = @{scope = $reducedPermissions}
-                            $commandContext |=> InvokeRequest "/oauth2PermissionGrants/$($_.id)" -RESTmethod PATCH -body $updatedScope | out-null
+                            $commandContext |=> InvokeRequest "/oauth2PermissionGrants/$($_.id)" -RESTMethod PATCH -body $updatedScope | out-null
                         } else {
                             write-verbose "Requested permissions were not present in existing grant, no change is necessary, skipping update for grant id='$($_.id)'"
                         }
                     }
                 }
             }
-        } else {
+        }
+
+        if ( $isAppOnly -or $AllPermissions.IsPresent ) {
             $targetPermissions = if ( $ApplicationPermissions ) {
                 foreach ( $permission in $ApplicationPermissions ) {
                     $::.ScopeHelper |=> GraphPermissionNameToId $permission 'Role' $CommandContext.connection $true
                 }
             }
 
-            $roleAssignments = $commandContext |=> InvokeRequest -uri servicePrincipals/$appSPId/appRoleAssignedTo -RESTMethod GET
+            $roleAssignments = if ( ! $consentObject ) {
+                $commandContext |=> InvokeRequest -uri servicePrincipals/$appSPId/appRoleAssignedTo -RESTMethod GET
+            } else {
+                $consentObject
+            }
 
             if ( $roleAssignments -and ( $roleAssignments | gm id ) ) {
                 $assignmentsToDelete = $roleAssignments | where {
-                    $AllApplicationPermissions.IsPresent -or
+                    $consentObject -ne $null -or
+                    $AllPermissions.IsPresent -or
                     $targetPermissions -contains $_.appRoleId
                 }
 

--- a/src/cmdlets/Remove-GraphItem.ps1
+++ b/src/cmdlets/Remove-GraphItem.ps1
@@ -158,7 +158,10 @@ function Remove-GraphItem {
             Version = $Version
             Headers = $Headers
             Permissions = $Permissions
-            Cloud = $Cloud
+        }
+
+        if ( $Cloud ) {
+            $commonRequestArguments['Cloud'] = $Cloud
         }
 
         if ( $Connection ) {

--- a/src/cmdlets/Set-GraphApplicationConsent.ps1
+++ b/src/cmdlets/Set-GraphApplicationConsent.ps1
@@ -33,7 +33,7 @@ function Set-GraphApplicationConsent {
         [parameter(parametersetname='allconfiguredpermissions', mandatory=$true)]
         [switch] $AllPermissions,
 
-        [switch] $ConsentAllUsers,
+        [switch] $ConsentForAllUsers,
 
         $UserIdToConsent,
 
@@ -52,7 +52,11 @@ function Set-GraphApplicationConsent {
 
         $app = $appAPI |=> GetApplicationByAppId $AppId
 
-        $appAPI |=> SetConsent $app.appid $DelegatedUserPermissions $ApplicationPermissions $AllPermissions.IsPresent $UserIdToConsent $ConsentAllUsers.IsPresent $app
+        if ( ! $app ) {
+            throw "Unable to find application with id '$AppId'"
+        }
+
+        $appAPI |=> SetConsent $app.appid $DelegatedUserPermissions $ApplicationPermissions $AllPermissions.IsPresent $UserIdToConsent $ConsentForAllUsers.IsPresent $app
     }
 
     end {}

--- a/src/cmdlets/Set-GraphApplicationConsent.ps1
+++ b/src/cmdlets/Set-GraphApplicationConsent.ps1
@@ -28,7 +28,7 @@ function Set-GraphApplicationConsent {
         [string[]] $DelegatedUserPermissions,
 
         [parameter(parametersetname='explicitscopes')]
-        [string[]] $AppOnlyPermissions,
+        [string[]] $ApplicationPermissions,
 
         [parameter(parametersetname='allconfiguredpermissions', mandatory=$true)]
         [switch] $AllPermissions,
@@ -52,7 +52,7 @@ function Set-GraphApplicationConsent {
 
         $app = $appAPI |=> GetApplicationByAppId $AppId
 
-        $appAPI |=> SetConsent $app.appid $DelegatedUserPermissions $AppOnlyPermissions $AllPermissions.IsPresent $UserIdToConsent $ConsentAllUsers.IsPresent $app
+        $appAPI |=> SetConsent $app.appid $DelegatedUserPermissions $ApplicationPermissions $AllPermissions.IsPresent $UserIdToConsent $ConsentAllUsers.IsPresent $app
     }
 
     end {}
@@ -60,5 +60,5 @@ function Set-GraphApplicationConsent {
 
 $::.ParameterCompleter |=> RegisterParameterCompleter Set-GraphApplicationConsent DelegatedUserPermissions (new-so PermissionParameterCompleter ([PermissionCompletionType]::DelegatedPermission))
 
-$::.ParameterCompleter |=> RegisterParameterCompleter Set-GraphApplicationConsent AppOnlyPermissions (new-so PermissionParameterCompleter ([PermissionCompletionType]::AppOnlyPermission))
+$::.ParameterCompleter |=> RegisterParameterCompleter Set-GraphApplicationConsent ApplicationPermissions (new-so PermissionParameterCompleter ([PermissionCompletionType]::AppOnlyPermission))
 

--- a/src/cmdlets/common/ConsentHelper.ps1
+++ b/src/cmdlets/common/ConsentHelper.ps1
@@ -27,8 +27,8 @@ ScriptClass ConsentHelper {
             $isOAuth2PermissionGrant = !(!($object | gm -erroraction ignore clientid))
 
             if ( $isOAuth2PermissionGrant ) {
-                $startTime = $object | gm startTime -erroraction ignore
-                $expiryTime = $object | gm expiryTime -erroraction ignore
+                $startTime = if ( $object | gm startTime -erroraction ignore ) { $object.startTime }
+                $expiryTime = if ( $object | gm expiryTime -erroraction ignore ) { $object.expiryTime }
                 $startTimeOffset = $::.DisplayTypeFormatter |=> UtcTimeStringToDateTimeOffset $startTime $true
                 $expiryTimeOffset = $::.DisplayTypeFormatter |=> UtcTimeStringToDateTimeOffset $expiryTime $true
                 $grantedTo = if ( $object.consentType -eq 'AllPrincipals' ) { 'AllUsers' } else { $object.PrincipalId }

--- a/src/common/ScopeHelper.ps1
+++ b/src/common/ScopeHelper.ps1
@@ -83,12 +83,7 @@ ScriptClass ScopeHelper -ArgumentList $__DefaultScopeData {
             if ( $scopes ) {
                 GetPermissionsByName $scopes Role $connection
             } else {
-                @(
-                    @{
-                        id = 'df021288-bdef-4463-88db-98f22de89214'
-                        type = 'Role'
-                    }
-                )
+                @()
             }
         }
 
@@ -96,10 +91,7 @@ ScriptClass ScopeHelper -ArgumentList $__DefaultScopeData {
             if ( $scopes ) {
                 GetPermissionsByName $scopes Scope $connection
             } else {
-                @{
-                    id = 'e1fe6dd8-ba31-4d61-89e7-88639da4683d'
-                    type = 'Scope'
-                }
+                @()
             }
         }
 

--- a/src/common/ScopeHelper.ps1
+++ b/src/common/ScopeHelper.ps1
@@ -21,6 +21,7 @@ ScriptClass ScopeHelper -ArgumentList $__DefaultScopeData {
     static {
         const GraphApplicationId 00000003-0000-0000-c000-000000000000
         const DefaultScopeQualifier ([Uri] 'https://graph.microsoft.com')
+        const OfflineAccessScopeId 7427e0e9-2fba-42fe-b0c0-848c9e6a8182
         $graphSP = $null
         $permissionsByIds = $null
         $appOnlyPermissionsByName = $null
@@ -79,9 +80,9 @@ ScriptClass ScopeHelper -ArgumentList $__DefaultScopeData {
             }
         }
 
-        function GetAppOnlyResourceAccessPermissions($scopes, $connection) {
-            if ( $scopes ) {
-                GetPermissionsByName $scopes Role $connection
+        function GetAppOnlyResourceAccessPermissions($roles, $connection) {
+            if ( $roles ) {
+                GetPermissionsByName $roles Role $connection
             } else {
                 @()
             }

--- a/src/graphservice/ApplicationAPI.ps1
+++ b/src/graphservice/ApplicationAPI.ps1
@@ -159,10 +159,12 @@ ScriptClass ApplicationAPI {
             if ( $userObjectId ) {
                 $isUserConsentNeeded = $true
                 write-verbose "Attempting to grant consent to app '$appId' for current user '$userObjectId'"
+            } else {
+                write-verbose "Unable to determine current user and all users consent not specified, so no consent for the user will be attempted; the current user is likely an app-only identity"
             }
             $userObjectId
         } else {
-            write-verbose "User consent was not specified, and tenant consent was specified, will attempt to consent all app permissions for the tenant"
+            write-verbose "User consent was not specified, and consent for required delegated permissions was specified, will attempt to consent those permissions for all users in the tenant"
             $isUserConsentNeeded = $true
         }
 
@@ -223,7 +225,7 @@ ScriptClass ApplicationAPI {
             }
         } else {
             $permissions = @()
-            if ( $appWithRequiredResource -and $appWithRequiredResource | gm requiredResourceAccess ) {
+            if ( $appWithRequiredResource -and ( $appWithRequiredResource | gm requiredResourceAccess -erroraction ignore ) ) {
                 $graphResourceAccess = $appWithRequiredResource.requiredResourceAccess | where resourceAppid -eq 00000003-0000-0000-c000-000000000000
                 $graphResourceAccess.resourceAccess | foreach {
                     if ( $_.type -eq 'Scope') {

--- a/src/graphservice/ApplicationObject.ps1
+++ b/src/graphservice/ApplicationObject.ps1
@@ -61,13 +61,13 @@ ScriptClass ApplicationObject {
     }
 
     function Register($skipRequiredResourcePermissions, $ConsentRequired, $userIdToConsent, $consentAllUsers, $scopes, $roles) {
-        $app = $this.AppAPI |=> RegisterApplication $this.AppId
+        $appSP = $this.AppAPI |=> RegisterApplication $this.AppId
 
         if ( $ConsentRequired ) {
-            $this.AppAPI |=> SetConsent $app.appId $scopes $roles (! $skipRequiredResourcePermissions) $userIdToConsent $consentAllUsers $app
+            $this.AppAPI |=> SetConsent $appSP.appId $scopes $roles (! $skipRequiredResourcePermissions) $userIdToConsent $consentAllUsers $appSP
         }
 
-        $app
+        $appSP
     }
 
     function __SetPublicApp($app, $redirectUris) {

--- a/src/graphservice/ApplicationObject.ps1
+++ b/src/graphservice/ApplicationObject.ps1
@@ -123,7 +123,7 @@ ScriptClass ApplicationObject {
         # a token is requested for the app
         if ( ! $hasScope ) {
             $resourceAccess += @{
-                id = '7427e0e9-2fba-42fe-b0c0-848c9e6a8182' # offline_access
+                id = $::.ScopeHelper.OfflineAccessScopeId
                 type = 'Scope'
             }
         }
@@ -133,7 +133,7 @@ ScriptClass ApplicationObject {
             signinAudience = $signInAudience
             requiredResourceAccess = @(
                 @{
-                    resourceAppId = '00000003-0000-0000-c000-000000000000'
+                    resourceAppId = $::.ScopeHelper.GraphApplicationId
                     resourceAccess = $resourceAccess
                 }
             )


### PR DESCRIPTION
This release adds features for additional API request customization and includes fixes for defects
related to AAD application management commands.

### New dependencies
None.

### Breaking changes

* The `Set-GraphApplicationConsent` parameter `AppOnlyPermissions` has been changed to `ApplicationPermissions` to for
  consistency with the changes made in `0.11.1` made to other commands with the same parameter. This change was intended
  to be part of the `0.11.1` release but was missed.
* The `AllApplicationPermissions` parameter of `Remove-GraphApplicationConsent` is renamed `AllPermissions`.
* The `AllTenantUsers` parameter of `Remove-GraphApplicationConsent` is renamed `ConsentForAllUsers`.

### New features

* By default, any request to Graph sets the `client-request-id` header with a unique GUID per request
* The `Get-GraphItem` and `Invoke-GraphRequest` commands support the following new parameters:
     * `ClientRequestId`: overrides the auto-generated value of the `client-request-id` header with the
       specified GUID value
     * `NoClientRequestId`: switch overrides the behavior of supplying an auto-generated `client-request-id` header
       and instead does not specify the header at all
* `UserAgent` parameter now added to `New-GraphConnection` and `Connect-Graph`: By default, AutoGraphPS specifies a particular
   user agent when sending requests. The `UserAgent` parameter allows these commands to set a specific user agent string
   used by all requests made through the resulting connection.
* As noted in the breaking changes section, the `ApplicationPermissions` parameter has replaced `AppOnlyPermissions` in
  `Set-GraphApplicationConsent`.
* `Remove-GraphApplicationConsent` now accepts pipeline input from output of `Get-GraphApplicationConsent` via
   `$ConsentGrant` parameter.

### Fixed defects

* `Remove-GraphItem` unusable without explicitly specifying `Cloud` parameter because of parameter binding issue in the default case.
* `New-GraphApplication` did not honor the `ConsentAllUsers` parameter and wrote an error about an undefined variable to
  the error stream. The incorret variable usage has been corrected and the parameter is now honored.
* `Register-GraphApplication`'s consent functionality explicitly or silently failed due to regression from breaking changes
  to other parts of the module in version 0.11.1. The command has been fixed to be compatible with the changes.
* `Get-GraphApplication` output extra words / characters in the `StartTime` field -- this formatting issue is now fixed.
* `Set-GraphAllicationConsent` was ignoring `ConsentAllUsers` and was not adding `AllPrincipals` consent grants -- this is fixed.
* `Remove-GraphConsent` syntax error due to reference to non-existent parameter, broken *All Users* consent removal
* `New-GraphApplication` adds minimal required permissions to the application object when permissions are not specified --
   only delegated permissions are added for public client apps, and only offline_access instead of `User.Read`.

### Checklist

- [x] All project tests pass successfully
