### PR TITLE
Minor fixes and new aliases for log related commands

### DIFF
--- a/AutoGraphPS-SDK.psd1
+++ b/AutoGraphPS-SDK.psd1
@@ -238,7 +238,10 @@ None.
 
 ### Fixed defects
 
-* Format-GraphLog specified the 'Wrap' parameter as a string rather than as switch -- the parameter was unusable
+* `Format-GraphLog` specified the 'Wrap' parameter as a string rather than as switch -- the parameter was unusable
+* `Format-GraphLog`: `Authentication` value for `View` parameter broken due to invalid property
+* `Permissions` column from `Get-GraphLog` only included requested permissions, not actual token permissions -- fixed
+  to reflect the latter
 
 '@
 

--- a/AutoGraphPS-SDK.psd1
+++ b/AutoGraphPS-SDK.psd1
@@ -12,7 +12,7 @@
 RootModule = 'autographps-sdk.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.14.0'
+ModuleVersion = '0.15.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -112,7 +112,7 @@ VariablesToExport = @(
 )
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = @('gge', 'ggi')
+AliasesToExport = @('gge', 'ggi', 'ggl', 'fgl')
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()
@@ -221,9 +221,9 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
-## AutoGraphPS-SDK 0.14.0 Release Notes
+## AutoGraphPS-SDK 0.15.0 Release Notes
 
-This release adds features for logging requests and responses.
+This release adds usability improvements and fixes.
 
 ### New dependencies
 None.
@@ -233,14 +233,12 @@ None.
 
 ### New features
 
-* The `Get-GraphLog` command enables retrieval of records of each request and response to the Graph
-* The `Format-GraphLog` command allows optimized formatting of Graph request logs from `Get-GraphLog`
-* The `Clear-GraphLog` command removes all previous log entries from the log
-* The `Set-GraphLogOption` command allows customization of the logging level and other logging behaviors
-* The `Get-GraphLogOption` command returns information about the current request logging configuration
+* The `ggl` alias for `Get-GraphLog` has been added
+* The `fgl` alias for `Format-GraphLog` has also been added
 
 ### Fixed defects
-None.
+
+* Format-GraphLog specified the 'Wrap' parameter as a string rather than as switch -- the parameter was unusable
 
 '@
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,6 @@
 * Add help support via write-information?
 
 * ------------------------------------
-* Use argumentcompleter advanced parameter rather than registerparametercompleter
 * Change get-graphconnection to take a connection or a graph
 * Refactor applicationhelper, applicationapi, and applicationobject to move api calls out of applicationobject
 * Convert some verbose statements to debug
@@ -382,6 +381,7 @@
 * switch to 3 columns by default -- remove class
 * Move some data to info, possibly show rwx
 * Make token caches per app-per cloud.
+* Use argumentcompleter advanced parameter rather than registerparametercompleter
 
 #### Stdposh improvements
 

--- a/autographps-sdk.psm1
+++ b/autographps-sdk.psm1
@@ -49,7 +49,7 @@ $cmdlets = @(
     'Unregister-GraphApplication'
 )
 
-$aliases = @('gge', 'ggi')
+$aliases = @('gge', 'ggi', 'ggl', 'fgl')
 
 $variables = @('GraphVerboseOutputPreference', 'LastGraphItems')
 

--- a/autographps-sdk.tests.ps1
+++ b/autographps-sdk.tests.ps1
@@ -1,4 +1,3 @@
-
 # Copyright 2019, Adam Edwards
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/REST/RequestLogEntry.ps1
+++ b/src/REST/RequestLogEntry.ps1
@@ -101,7 +101,11 @@ ScriptClass RequestLogEntry {
         $userObjectId = if ( $userInfo ) { $userInfo.userObjectId }
         $userUpn = if ( $userInfo ) { $userInfo.userId }
         $tenantId = if ( $connection ) { $connection.identity.tenantdisplayid }
-        $scopes = if ( $connection ) { $connection.scopes }
+        $scopes = if ( $connection -and
+                       $connection.identity -and
+                       ( $connection.identity.token | gm scopes -erroraction ignore ) ) {
+                           $connection.identity.token.scopes
+                       }
         $version = if ( $restRequest.Uri.segments.length -ge 3 ) { $restRequest.Uri.segments[1].trimend('/') }
         $query = $restRequest.Uri.query
 

--- a/src/aliases.ps1
+++ b/src/aliases.ps1
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set-alias gge Get-GraphError
-set-alias ggi Get-GraphItem
+set-alias ggl Get-GraphLog
+set-alias fgl Format-GraphLog
 

--- a/src/aliases.ps1
+++ b/src/aliases.ps1
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set-alias gge Get-GraphError
+set-alias ggi Get-GraphItem
 set-alias ggl Get-GraphLog
 set-alias fgl Format-GraphLog
 

--- a/src/cmdlets/Format-GraphLog.ps1
+++ b/src/cmdlets/Format-GraphLog.ps1
@@ -193,7 +193,7 @@ function Format-GraphLog {
 
         [switch] $ShowError,
 
-        [string] $Wrap,
+        [switch] $Wrap,
 
         [switch] $HideTableHeaders,
 

--- a/src/cmdlets/Format-GraphLog.ps1
+++ b/src/cmdlets/Format-GraphLog.ps1
@@ -39,7 +39,7 @@ $Views = @{
         'StatusCode'
         'Method'
         'ResourceUri'
-        'Scopes'
+        'Permissions'
     )
     Debug = @(
         'RequestTimestamp'
@@ -224,9 +224,12 @@ function Format-GraphLog {
     process {
         $propertyMap = @{}
 
-        $targetProperties | foreach {
-            if ( $_ -ne $::.RequestLogEntry.ERROR_MESSAGE_EXTENDED_FIELD ) {
-                $propertyValue = $InputObject | select -expandproperty $_
+        foreach ( $targetProperty in $targetProperties ) {
+            if ( $targetProperty -ne $::.RequestLogEntry.ERROR_MESSAGE_EXTENDED_FIELD ) {
+                $propertyValue = if ( $InputObject | gm  $targetProperty ) {
+                    $InputObject | select -expandproperty $targetProperty
+                }
+
                 $augmentedValue = if ( $propertyValue -is [DateTimeOffset] ) {
                     # DateTimeOffset has a very long format that includes the time
                     # zone offset -- use something shorter to save display space
@@ -234,7 +237,7 @@ function Format-GraphLog {
                 } else {
                     $propertyValue
                 }
-                $propertyMap[$_] = $augmentedValue
+                $propertyMap[$targetProperty] = $augmentedValue
             }
         }
 


### PR DESCRIPTION
### Description

This release adds usability improvements and fixes.

### New dependencies
None.

### Breaking changes
None.

### New features

* The `ggl` alias for `Get-GraphLog` has been added
* The `fgl` alias for `Format-GraphLog` has also been added

### Fixed defects

* `Format-GraphLog` specified the 'Wrap' parameter as a string rather than as switch -- the parameter was unusable
* `Format-GraphLog`: `Authentication` value for `View` parameter broken due to invalid property
* `Permissions` column from `Get-GraphLog` only included requested permissions, not actual token permissions -- fixed
  to reflect the latter

- [x] All project tests pass successfully