### PR TITLE
Fix regressions in application commands from last release, old sorting defect, improve usability

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,6 @@
 
 ## To-do items -- prioritized
 
-* Add ToAbsoluteUri method GraphUtilities
 * Add more command help
 * Add view to get-grapherror
 * Refactor auth providers
@@ -359,6 +358,8 @@
 * Add logging implementation
 * Change Get-GraphItem, Remove-GraphItem to Get-GraphResource, Remove-GraphResource
 * Change name of ODataFilter parameter on several commands to Filter
+* Add ToAbsoluteUri method GraphUtilities
+* Make property parameter second positional parameter
 
 ### Postponed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,8 @@
 
 ## To-do items -- prioritized
 
+* Add 'NoRequest' mode to output what request would have been made.
+* Add batching support
 * Add more command help
 * Add view to get-grapherror
 * Refactor auth providers
@@ -360,6 +362,7 @@
 * Change name of ODataFilter parameter on several commands to Filter
 * Add ToAbsoluteUri method GraphUtilities
 * Make property parameter second positional parameter
+* Use begin / process / end for Invoke-GraphRequest and Get-GraphResource commands
 
 ### Postponed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,8 @@
 
 ## To-do items -- prioritized
 
+* Add Get-LastGraphResponse with view parameters, remove LASTGRAPHITEMS
+* Add output types to as many commands as possible
 * Add 'NoRequest' mode to output what request would have been made.
 * Add batching support
 * Add more command help

--- a/autographps-sdk.psd1
+++ b/autographps-sdk.psd1
@@ -231,6 +231,8 @@ None.
 
 ### Breaking changes
 
+* The pipeline is now explicitly supported by the `Invoke-GraphRequest` and `Get-GraphResource` commands -- graph URI's may be supplied to the pipeline and the commands will retrieve results for each URI. This may have subtle behavior differences from the previous implementation which modeled the Uri parameter as an array -- it is now a scalar object with multiple URIs available only from the pipeline and not by passing an array of URIs for the URI parameter.
+
 ### New features
 
 * The `Get-GraphResource` command's `Select` parameter has been renamed to `Property` to be consistent with related commands in `AutoGraphPS`. However the command retains a `Select` alias for compatibility with the original parameter name and to support users accustomed to the Graph terminology for projection of a record's fields.
@@ -238,7 +240,9 @@ None.
 
 ### Fixed defects
 
-# The `Invoke-GraphRequest` and `Get-GraphResource` commands incorrectly handled the `Expand` parameter in cases where the syntax `-Expand:$false` was used -- instead of being correctly interpreted as the parameter not being specified, it was treated as if it had been expressed `-Expand`, resulting in invalid queries to Graph. This is now fixed.
+* The `Invoke-GraphRequest` and `Get-GraphResource` commands incorrectly handled the `Expand` parameter in cases where the syntax `-Expand:$false` was used -- instead of being correctly interpreted as the parameter not being specified, it was treated as if it had been expressed `-Expand`, resulting in invalid queries to Graph. This is now fixed.
+* The `Descending` parameter of `Invoke-GraphRequest` and `Get-GraphResource` was ignored in the mainstream case of the `OrderBy` parameter not being hash table. This has been fixed.
+* The `Skip` parameter on `Invoke-GraphRequest` and `Get-GraphResource` would generate an incorrect URI when used resulting in a `BadRequest` response from Graph -- `Skip` was unusable. This issue has been fixed.
 
 None.
 

--- a/autographps-sdk.psd1
+++ b/autographps-sdk.psd1
@@ -240,6 +240,21 @@ None.
 
 ### Fixed defects
 
+* The AAD Application-related commands including `Get-GraphApplication`, `New-GraphApplication`, and `Remove-GraphApplication` commands were unusable due to a breaking change to parameter names in the `0.19.0` release of this module for the `Invoke-GraphRequest` command. This release includes the fix. The affected commands were:
+
+    * `Get-GraphApplication`
+    * `Get-GraphApplicationCertificate`
+    * `Get-GraphApplicationConsent`
+    * `Get-GraphApplicationServicePrincipal`
+    * `New-GraphApplication`
+    * `New-GraphApplicationCertificate`
+    * `Register-GraphApplication`
+    * `Remove-GraphApplication`
+    * `Remove-GraphApplicationCertificate`
+    * `Remove-GraphApplicationConsent`
+    * `Set-GraphApplicationConsent`
+    * `Unregister-GraphApplication`
+
 * The `Invoke-GraphRequest` and `Get-GraphResource` commands incorrectly handled the `Expand` parameter in cases where the syntax `-Expand:$false` was used -- instead of being correctly interpreted as the parameter not being specified, it was treated as if it had been expressed `-Expand`, resulting in invalid queries to Graph. This is now fixed.
 * The `Descending` parameter of `Invoke-GraphRequest` and `Get-GraphResource` was ignored in the mainstream case of the `OrderBy` parameter not being hash table. This has been fixed.
 * The `Skip` parameter on `Invoke-GraphRequest` and `Get-GraphResource` would generate an incorrect URI when used resulting in a `BadRequest` response from Graph -- `Skip` was unusable. This issue has been fixed.

--- a/autographps-sdk.psd1
+++ b/autographps-sdk.psd1
@@ -223,7 +223,7 @@ PrivateData = @{
         ReleaseNotes = @'
 ## AutoGraphPS-SDK 0.20.0 Release Notes
 
-This release includes improvements to existing commands.
+This release includes improvements to existing commands and important fixes for major regressions in the previous release.
 
 ### New dependencies
 
@@ -231,7 +231,7 @@ None.
 
 ### Breaking changes
 
-* The pipeline is now explicitly supported by the `Invoke-GraphRequest` and `Get-GraphResource` commands -- graph URI's may be supplied to the pipeline and the commands will retrieve results for each URI. This may have subtle behavior differences from the previous implementation which modeled the Uri parameter as an array -- it is now a scalar object with multiple URIs available only from the pipeline and not by passing an array of URIs for the URI parameter.
+* The object pipeline is now explicitly supported by the `Invoke-GraphRequest` and `Get-GraphResource` commands -- graph URI's may be supplied to the pipeline and the commands will retrieve results for each URI. This may have subtle behavior differences from the previous implementation which modeled the Uri parameter as an array -- it is now a scalar object with multiple URIs available only from the pipeline and not by passing an array of URIs for the URI parameter.
 
 ### New features
 

--- a/autographps-sdk.psd1
+++ b/autographps-sdk.psd1
@@ -234,8 +234,11 @@ None.
 ### New features
 
 * The `Get-GraphResource` command's `Select` parameter has been renamed to `Property` to be consistent with related commands in `AutoGraphPS`. However the command retains a `Select` alias for compatibility with the original parameter name and to support users accustomed to the Graph terminology for projection of a record's fields.
+* The `Property` parameter (aka `Select` per above) is now the second positional parameter and `Filter` is no longer a positional parameter. Now you can use an invocation such as `Get-GraphResource me id, displayName` to get only specific properties. This change is made in part because `Filter` is seen as a less common and more advanced use case due to the need to know OData syntax. This is also consistent with other commands in related modules such as `AutoGraphPS` where `Property` is a positional parameter and `Filter` is not.
 
 ### Fixed defects
+
+# The `Invoke-GraphRequest` and `Get-GraphResource` commands incorrectly handled the `Expand` parameter in cases where the syntax `-Expand:$false` was used -- instead of being correctly interpreted as the parameter not being specified, it was treated as if it had been expressed `-Expand`, resulting in invalid queries to Graph. This is now fixed.
 
 None.
 

--- a/autographps-sdk.psd1
+++ b/autographps-sdk.psd1
@@ -12,7 +12,7 @@
 RootModule = 'autographps-sdk.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.19.0'
+ModuleVersion = '0.20.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -221,9 +221,9 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
-## AutoGraphPS-SDK 0.19.0 Release Notes
+## AutoGraphPS-SDK 0.20.0 Release Notes
 
-This release includes a significant breaking change -- two commands have been renamed.
+This release includes improvements to existing commands.
 
 ### New dependencies
 
@@ -231,16 +231,9 @@ None.
 
 ### Breaking changes
 
-* Renamed commands: The following commands have been renamed:
-  * `Get-GraphItem` is renamed to `Get-GraphResource`
-  * `Remove-GraphItem` is renamed to `Remove-GraphResource`
-* The `ggi` alias is renamed to `ggr` to reflect the change in the name of the command it originally aliased, `Get-GraphItem`
-* `ItemRelativeUri` and `RelativeUri` parameters for the commands `Get-GraphResource` and `Invoke-GraphRequest` have been renamed to `Uri`
-* The `ODataFilter` parameter on numerous commands including `Get-GraphResource` and `InvokeGraphRequest` has been renamed to `Filter`
-
 ### New features
 
-* The GraphContext class has a new public property, Id. Id is a guid that uniquely identifies the context and can be used for cases such as hashing.
+* The `Get-GraphResource` command's `Select` parameter has been renamed to `Property` to be consistent with related commands in `AutoGraphPS`. However the command retains a `Select` alias for compatibility with the original parameter name and to support users accustomed to the Graph terminology for projection of a record's fields.
 
 ### Fixed defects
 

--- a/src/REST/GraphRequest.ps1
+++ b/src/REST/GraphRequest.ps1
@@ -73,10 +73,9 @@ ScriptClass GraphRequest {
             throw "Web request cannot proceed -- connection status is set to offline"
         }
 
-        $queryParameters = if ( $this.Query -is [object[]] ) {
-            $this.Query
-        } else {
-            @($this.Query)
+        $queryParameters = $this.query
+        if ( $this.Query -isnot [object[]] ) {
+            $queryParameters = , $this.Query
         }
 
         if ($pageStartIndex -ne $null) {
@@ -124,7 +123,7 @@ ScriptClass GraphRequest {
         $restResponse
     }
 
-    function __AddQueryParameters($parameters) {
+    function __AddQueryParameters([string[]] $parameters) {
         $components = @()
 
         $parameters | foreach {

--- a/src/cmdlets/Get-GraphResource.ps1
+++ b/src/cmdlets/Get-GraphResource.ps1
@@ -154,9 +154,9 @@ function Get-GraphResource {
         [parameter(position=0,mandatory=$true)]
         [Uri[]] $Uri,
 
-        [parameter(position=1)]
         [String] $Filter = $null,
 
+        [parameter(position=1)]
         [Alias('Property')]
         [String[]] $Select = $null,
 

--- a/src/cmdlets/Get-GraphResource.ps1
+++ b/src/cmdlets/Get-GraphResource.ps1
@@ -157,6 +157,7 @@ function Get-GraphResource {
         [parameter(position=1)]
         [String] $Filter = $null,
 
+        [Alias('Property')]
         [String[]] $Select = $null,
 
         [String] $Search = $null,

--- a/src/cmdlets/common/ApplicationHelper.ps1
+++ b/src/cmdlets/common/ApplicationHelper.ps1
@@ -78,7 +78,7 @@ ScriptClass ApplicationHelper {
             }
 
             write-verbose "Querying for applications at version $apiVersion' with uri '$uri, filter '$filter', select '$select'"
-            Invoke-GraphRequest -Method $queryMethod -RelativeUri $uri @requestArguments -version $apiVersion
+            Invoke-GraphRequest -Method $queryMethod -Uri $uri @requestArguments -version $apiVersion
         }
     }
 }

--- a/src/cmdlets/common/QueryHelper.ps1
+++ b/src/cmdlets/common/QueryHelper.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019, Adam Edwards
+# Copyright 2020, Adam Edwards
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ ScriptClass QueryHelper {
     static {
         function GetOrderQueryFromOrderByParameters($orderByParameters, [bool] $descendingDefault) {
             $sortColumns = switch($OrderByParameters.Gettype().name) {
-                'String' { @{$orderByParameters=$false} }
+                'String' { @{$orderByParameters = $descendingDefault} }
                 'HashTable' { $orderByParameters }
                 'object[]' {
                     $normalized = @{}
@@ -38,8 +38,11 @@ ScriptClass QueryHelper {
                 if ( $isDescending -isnot [bool] ) {
                     throw [ArgumentException]::new("Specified sort column '$($_.tostring())' was assigned invalid type '$($isDescending.gettype())' for direction -- it must be of type 'bool'")
                 }
-                $direction = if ( $isDescending ) { 'desc' } else { '' }
-                '{0} {1}' -f $_, $direction
+                if ( $isDescending ) {
+                    $_ + ' desc'
+                } else {
+                    $_
+                }
             }
 
             $columnEntries -join ','


### PR DESCRIPTION
### Description

This release includes improvements to existing commands and important fixes for major regressions in the previous release.

### New dependencies

None.

### Breaking changes

* The pipeline is now explicitly supported by the `Invoke-GraphRequest` and `Get-GraphResource` commands -- graph URI's may be supplied to the pipeline and the commands will retrieve results for each URI. This may have subtle behavior differences from the previous implementation which modeled the Uri parameter as an array -- it is now a scalar object with multiple URIs available only from the pipeline and not by passing an array of URIs for the URI parameter.

### New features

* The `Get-GraphResource` command's `Select` parameter has been renamed to `Property` to be consistent with related commands in `AutoGraphPS`. However the command retains a `Select` alias for compatibility with the original parameter name and to support users accustomed to the Graph terminology for projection of a record's fields.
* The `Property` parameter (aka `Select` per above) is now the second positional parameter and `Filter` is no longer a positional parameter. Now you can use an invocation such as `Get-GraphResource me id, displayName` to get only specific properties. This change is made in part because `Filter` is seen as a less common and more advanced use case due to the need to know OData syntax. This is also consistent with other commands in related modules such as `AutoGraphPS` where `Property` is a positional parameter and `Filter` is not.

### Fixed defects

* The AAD Application-related commands including `Get-GraphApplication`, `New-GraphApplication`, and `Remove-GraphApplication` commands were unusable due to a breaking change to parameter names in the `0.19.0` release of this module for the `Invoke-GraphRequest` command. This release includes the fix. The affected commands were:

    * `Get-GraphApplication`
    * `Get-GraphApplicationCertificate`
    * `Get-GraphApplicationConsent`
    * `Get-GraphApplicationServicePrincipal`
    * `New-GraphApplication`
    * `New-GraphApplicationCertificate`
    * `Register-GraphApplication`
    * `Remove-GraphApplication`
    * `Remove-GraphApplicationCertificate`
    * `Remove-GraphApplicationConsent`
    * `Set-GraphApplicationConsent`
    * `Unregister-GraphApplication`

* The `Invoke-GraphRequest` and `Get-GraphResource` commands incorrectly handled the `Expand` parameter in cases where the syntax `-Expand:$false` was used -- instead of being correctly interpreted as the parameter not being specified, it was treated as if it had been expressed `-Expand`, resulting in invalid queries to Graph. This is now fixed.
* The `Descending` parameter of `Invoke-GraphRequest` and `Get-GraphResource` was ignored in the mainstream case of the `OrderBy` parameter not being hash table. This has been fixed.
* The `Skip` parameter on `Invoke-GraphRequest` and `Get-GraphResource` would generate an incorrect URI when used resulting in a `BadRequest` response from Graph -- `Skip` was unusable. This issue has been fixed.

None.

- [x] All project tests pass successfully
