### PR TITLE
OData Context URI parsing and interpretation, paging refinements, and Initial preview of delta query support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## To-do items -- prioritized
 
-* Add delta
+* Add AllResults option to Get-GraphResource and Invoke-GraphRequest, and corresponding preference variable
 * Add Start-GraphDeltaJob
 * Add Get-LastGraphResponse with view parameters, remove LASTGRAPHITEMS
 * Add output types to as many commands as possible
@@ -364,6 +364,7 @@
 * Use begin / process / end for Invoke-GraphRequest and Get-GraphResource commands
 * Add 'NoRequest' mode to output what request would have been made.
 * Make Uri argument a non-array
+* Add delta
 
 ### Postponed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,8 @@
 
 ## To-do items -- prioritized
 
+* Add delta
+* Add Start-GraphDeltaJob
 * Add Get-LastGraphResponse with view parameters, remove LASTGRAPHITEMS
 * Add output types to as many commands as possible
 * Add batching support

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,7 @@
 
 ## To-do items -- prioritized
 
+* Make set-graphapplicationconsent idempotent (read grants / roles first, only add those that don't exist)
 * When invoke-graphrequest creates an object through post, it should add the id to the uri for the itemcontext
 * Add AllResults option to Get-GraphResource and Invoke-GraphRequest, and corresponding preference variable
 * Add Start-GraphDeltaJob

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,7 @@
 
 ## To-do items -- prioritized
 
+* When invoke-graphrequest creates an object through post, it should add the id to the uri for the itemcontext
 * Add AllResults option to Get-GraphResource and Invoke-GraphRequest, and corresponding preference variable
 * Add Start-GraphDeltaJob
 * Add Get-LastGraphResponse with view parameters, remove LASTGRAPHITEMS
@@ -101,7 +102,7 @@
 
 * Test schema and basic tests offline
 * Unauthenticated functional tests
-* Parse odata context
+
 * Background runspace jobs
 
 * Release
@@ -365,6 +366,7 @@
 * Add 'NoRequest' mode to output what request would have been made.
 * Make Uri argument a non-array
 * Add delta
+* Parse odata context
 
 ### Postponed
 

--- a/autographps-sdk.psd1
+++ b/autographps-sdk.psd1
@@ -248,6 +248,7 @@ None.
   * New methods in `GraphUtilities`:
     * `GetAbstractUriFromResponseObject` returns a close approximation of a URI that can be used to make a request for that response.
     * `GetOptionalTypeFromResponseObject` returns the parsed type from `@odata.type` for a given object if it is present
+* AAD Application commands such as New-GraphApplication, Get-GraphApplication, Set-GraphApplicationConsent, etc., have been updated to use Graph API version v1.0 instead of beta since all application functionality is now present in v1.0.
 
 ### Fixed defects
 

--- a/autographps-sdk.psd1
+++ b/autographps-sdk.psd1
@@ -224,7 +224,7 @@ PrivateData = @{
         ReleaseNotes = @'
 ## AutoGraphPS-SDK 0.22.0 Release Notes
 
-This release adds the initial support for delta query and also improves and refines general result paging capabilities.
+This release adds helper libraries for interpreting OData protocol response metadata, simplifies result paging capabilities, adds a detailed Graph response output format for applications building complex scenarios that require protocol awareness, and adds preview support for delta query.
 
 ### New dependencies
 
@@ -233,6 +233,7 @@ None.
 ### Breaking changes
 
 * The `IncludeFullResponse` parameter is no longer supported by the `Invoke-GraphRequest` command. It has been superseded by the `AsResponseDetail` parameter added in this release.
+* Applications created by New-GraphApplication no longer include 'http://localhost' and 'urn:ietf:wg:oauth:2.0:oob' by default. The only default URI specified for these application is 'https://login.microsoftonline.com/common/oauth2/nativeclient'.
 
 ### New features
 
@@ -248,6 +249,8 @@ None.
     * `GetOptionalTypeFromResponseObject` returns the parsed type from `@odata.type` for a given object if it is present
 
 ### Fixed defects
+
+* V2 public client authentication fails with mismatch reply URL when using a non-default app id unless localhost is configured as a reply url. The only workaround was to add localhost as a reply url to the app because no reply URL was specified by AutoGraphPS to the MSAL library when making the request. From an MSAL (and possibly from the protocol) standpoint, this is the equivalent of specifying no reply url. The fix is to specify whatever reply URL is configured in the local connection; by default, the app now uses 'https://login.microsoftonline.com/common/oauth2/nativeclient', which is now the default reply URL for applications created by New-GraphApplication.
 
 '@
 

--- a/autographps-sdk.psd1
+++ b/autographps-sdk.psd1
@@ -242,10 +242,12 @@ None.
   * `DeltaToken`: This parameter provides a way to request only the incremental changes that would be returned compared to a previous request issued by this command using the Delta parameter.
   * `NoPaging`: This disables the default behavior of the command that issues multiple requests to Graph until all results for the initial request have been retrieved. When this command is specified, the results are returned using the `AsResponseDetail` format so that the caller has the additional information beyond the request results necessary to retrieve the additional results if desired.
   * `PageSizePreference`: directs the command to issues requests that instruct the Graph API to return a specific maximum number of items in each page of results. This parameter will only take effect if Graph honors it for the particular request.
+  * `ResponseContext` class: This class parses the `ODataContext` property, an [OData Context URL](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_ContextURL) to return information about the type of the response and the URI used to make the request.
+  * New methods in `GraphUtilities`:
+    * `GetAbstractUriFromResponseObject` returns a close approximation of a URI that can be used to make a request for that response.
+    * `GetOptionalTypeFromResponseObject` returns the parsed type from `@odata.type` for a given object if it is present
 
 ### Fixed defects
-
-* The default maximum of 10 results was not honored by `Invoke-GraphRequest` and `Get-GraphResource`. This is now honored -- by default only 10 results are returned. To revert to the old behavior where paging was indefinite, a new parameter is probably needed.
 
 '@
 

--- a/autographps-sdk.psd1
+++ b/autographps-sdk.psd1
@@ -184,6 +184,7 @@ AliasesToExport = @('gge', 'ggr', 'gcat', 'Get-GraphContent', 'ggl', 'fgl')
         '.\src\common\GraphUtilities.ps1'
         '.\src\common\PreferenceHelper.ps1'
         '.\src\common\ProgressWriter.ps1'
+        '.\src\common\ResponseContext.ps1'
         '.\src\common\ScopeHelper.ps1'
         '.\src\common\Secret.ps1'
         '.\src\graphservice\ApplicationAPI.ps1'

--- a/autographps-sdk.psd1
+++ b/autographps-sdk.psd1
@@ -193,6 +193,7 @@ AliasesToExport = @('gge', 'ggr', 'gcat', 'Get-GraphContent', 'ggl', 'fgl')
         '.\src\REST\GraphErrorRecorder.ps1'
         '.\src\REST\GraphRequest.ps1'
         '.\src\REST\GraphResponse.ps1'
+        '.\src\REST\HttpUtilities.ps1'
         '.\src\REST\RequestLog.ps1'
         '.\src\REST\RequestLogEntry.ps1'
         '.\src\REST\RESTRequest.ps1'
@@ -251,6 +252,8 @@ None.
 ### Fixed defects
 
 * V2 public client authentication fails with mismatch reply URL when using a non-default app id unless localhost is configured as a reply url. The only workaround was to add localhost as a reply url to the app because no reply URL was specified by AutoGraphPS to the MSAL library when making the request. From an MSAL (and possibly from the protocol) standpoint, this is the equivalent of specifying no reply url. The fix is to specify whatever reply URL is configured in the local connection; by default, the app now uses 'https://login.microsoftonline.com/common/oauth2/nativeclient', which is now the default reply URL for applications created by New-GraphApplication.
+* Get-GraphLog and related commands did not function correctly on PowerShell 7 -- error responses were logged with incomplete fields including an invalid http status code of 0. This was due to the underlying http client type being different on PowerShell 7 vs. PowerShell 5, and the methods and properties were different for this class, resulting in errors when trying to read data from the response. This seemed to only be an issue for error responses. The fix ensures that the type differences are accounted for on the different platforms and restores the error logging.
+* Fixed an error where apps created by New-GraphApplication were registered such that device code authentication flow could not be used to sign-in with the apps. They were missing the fallbackPublicClient property for the app, which is apparently required for that flow to work. This is now fixed, and this restores device code flow login for these apps, which is critical for PowerShell 7 and later since they do not support the web browser controls used to sign in on PowerShell 5.
 
 '@
 

--- a/src/REST/GraphResponse.ps1
+++ b/src/REST/GraphResponse.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019, Adam Edwards
+# Copyright 2020, Adam Edwards
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ ScriptClass GraphResponse {
     $Entities = $null
     $ODataContext = strict-val [Uri]
     $NextLink = strict-val [Uri]
+    $DeltaLink = strict-val [Uri]
     $Metadata = strict-val [HashTable] @{}
 
     function __initialize ( $restResponse ) {
@@ -30,6 +31,7 @@ ScriptClass GraphResponse {
 
         $this.ODataContext = $this.metadata['@odata.context']
         $this.NextLink = $this.metadata['@odata.nextLink']
+        $this.DeltaLink = $this.metadata['@odata.deltaLink']
     }
 
     function Content {

--- a/src/REST/HttpUtilities.ps1
+++ b/src/REST/HttpUtilities.ps1
@@ -1,0 +1,36 @@
+# Copyright 2020, Adam Edwards
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ScriptClass HttpUtilities {
+    static {
+        function NormalizeHeaders($headers) {
+            # See if this is a HashTable-like object by looking for a 'keys' member
+            if ( $headers | gm keys -erroraction ignore ) {
+                # It looks like a HashTable, so just return it as-is since HashTable
+                # is the desired output format
+                $headers
+            } else {
+                # For PowerShell 7, instead of representing headers using an object with
+                # an interface similar to HashTable, sometimes a different type may be emitted,
+                # Particularly for error responses. Convert this to an actual [HashTable]
+                # to ensure a consistent interace in all cases.
+                $headerTable = @{}
+                $headers | foreach {
+                    $headerTable.Add($_.key, $_.value)
+                }
+                $headerTable
+            }
+        }
+    }
+}

--- a/src/REST/HttpUtilities.ps1
+++ b/src/REST/HttpUtilities.ps1
@@ -16,20 +16,27 @@ ScriptClass HttpUtilities {
     static {
         function NormalizeHeaders($headers) {
             # See if this is a HashTable-like object by looking for a 'keys' member
-            if ( $headers | gm keys -erroraction ignore ) {
-                # It looks like a HashTable, so just return it as-is since HashTable
-                # is the desired output format
-                $headers
-            } else {
-                # For PowerShell 7, instead of representing headers using an object with
-                # an interface similar to HashTable, sometimes a different type may be emitted,
-                # Particularly for error responses. Convert this to an actual [HashTable]
-                # to ensure a consistent interace in all cases.
-                $headerTable = @{}
-                $headers | foreach {
-                    $headerTable.Add($_.key, $_.value)
+            if ( $headers ) {
+                if ( $headers | gm keys -erroraction ignore ) {
+                    # It looks like a HashTable, so just return it as-is since HashTable
+                    # is the desired output format
+                    $headers
+                } else {
+                    # For PowerShell 7, instead of representing headers using an object with
+                    # an interface similar to HashTable, sometimes a different type may be emitted,
+                    # Particularly for error responses. Convert this to an actual [HashTable]
+                    # to ensure a consistent interace in all cases.
+                    $headerTable = @{}
+
+                    $headers | foreach {
+                        if ( $headers -is [System.Net.WebHeaderCollection] ) {
+                            $headerTable.Add($_, $headers[$_])
+                        } else {
+                            $headerTable.Add($_.key, $_.value)
+                        }
+                    }
+                    $headerTable
                 }
-                $headerTable
             }
         }
     }

--- a/src/REST/RESTRequest.ps1
+++ b/src/REST/RESTRequest.ps1
@@ -14,6 +14,7 @@
 
 . (import-script RESTResponse)
 . (import-script ../common/PreferenceHelper)
+. (import-script HttpUtilities)
 
 ScriptClass RESTRequest {
     static {

--- a/src/REST/RESTRequest.ps1
+++ b/src/REST/RESTRequest.ps1
@@ -99,7 +99,7 @@ ScriptClass RESTRequest {
                 # There are a variety of exceptions that can be encountered depending on the underlying .NET http client implementation
                 # TODO: Abstract this to a class that has knowledge of the specifics of the http clients
                 $exceptionType = $_.exception.gettype()
-                if ( $exceptionType -notin [System.Net.WebException], [Microsoft.PowerShell.Commands.HttpResponseException] -and ! $exceptionType.fullname.startswith('System.Net.Http') ) {
+                if ( $exceptionType -ne [System.Net.WebException] -and $exceptionType.fullName -ne 'Microsoft.PowerShell.Commands.HttpResponseException' -and ! $exceptionType.fullname.startswith('System.Net.Http') ) {
                     write-verbose "Encountered unexpected exception of type '$($exceptionType.FullName)'"
                     throw
                 }

--- a/src/auth/V2AuthProvider.ps1
+++ b/src/auth/V2AuthProvider.ps1
@@ -58,7 +58,7 @@ ScriptClass V2AuthProvider {
             $confidentialApp
         } else {
             write-verbose "Public app context not found -- will create new context"
-            $publicApp = [Microsoft.Identity.Client.PublicClientApplicationBuilder]::Create($App.AppId).WithAuthority($authUri, $true).Build()
+            $publicApp = [Microsoft.Identity.Client.PublicClientApplicationBuilder]::Create($App.AppId).WithAuthority($authUri, $true).WithRedirectUri($app.RedirectUri).Build()
 
             $this |=> __AddAppContext $false $app.AppId $authUri $publicApp $groupId
 

--- a/src/client/Application.ps1
+++ b/src/client/Application.ps1
@@ -15,6 +15,7 @@
 ScriptClass Application {
     static {
         const DefaultAppId (strict-val [Guid] '9825d80c-5aa0-42ef-bf13-61e12116704c')
+        const DefaultRedirectUri 'https://login.microsoftonline.com/common/oauth2/nativeclient'
         $SupportsBrowserSignin = $PSVersionTable.PSEdition -eq 'Desktop'
     }
 }

--- a/src/client/GraphApplication.ps1
+++ b/src/client/GraphApplication.ps1
@@ -47,7 +47,7 @@ ScriptClass GraphApplication {
     }
 
     function __GetDefaultRedirectUri($appId) {
-        'urn:ietf:wg:oauth:2.0:oob'
+        'https://login.microsoftonline.com/common/oauth2/nativeclient'
     }
 
     function IsConfidential {

--- a/src/client/GraphApplication.ps1
+++ b/src/client/GraphApplication.ps1
@@ -42,12 +42,8 @@ ScriptClass GraphApplication {
         $this.RedirectUri = if ( $RedirectUri ) {
             $RedirectUri
         } else {
-            __GetDefaultRedirectUri $this.AppId
+            $::.Application.DefaultRedirectUri
         }
-    }
-
-    function __GetDefaultRedirectUri($appId) {
-        'https://login.microsoftonline.com/common/oauth2/nativeclient'
     }
 
     function IsConfidential {

--- a/src/client/GraphIdentity.ps1
+++ b/src/client/GraphIdentity.ps1
@@ -103,6 +103,7 @@ ScriptClass GraphIdentity {
 
         $authUri = $graphEndpoint |=> GetAuthUri $this.TenantName
         write-verbose ("Sending auth request to auth uri '{0}'" -f $authUri)
+        write-verbose ("Using redirect uri (reply url) '{0}'" -f $this.App.RedirectUri)
 
         if ( ! $this.scriptclass.AuthProvidersInitialized ) {
             $::.AuthProvider |=> InitializeProviders

--- a/src/client/GraphIdentity.ps1
+++ b/src/client/GraphIdentity.ps1
@@ -39,6 +39,14 @@ ScriptClass GraphIdentity {
         $this.GraphEndpoint = $graphEndpoint
         $this.TenantName = $tenantName
 
+        $defaultAppId = $::.Application.DefaultAppId.tostring()
+        $chinaEndpointUri = ( $::.GraphEndpoint |=> GetCloudEndpoint ChinaCloud MSGraph ).Graph.tostring().trimend('/')
+
+        if ( ( $graphEndpoint.Graph.tostring().trimend('/') -eq $chinaEndpointUri ) -and
+             ( $app.AppId.tostring() -eq $defaultAppId ) ) {
+             write-warning "Initializing connection to China cloud using the default application identifier '$defaultAppId', but this public cloud app may not be available in the China cloud, so authentication may fail. Consider creating a new public client application in a China cloud tenant and specify that application's application identifier (also known as client id) with Connect-Graph or related commands via their AppId parameter if you experience authentication failures and retry the failing command."
+        }
+
         $this |=> __UpdateTenantDisplayInfo
     }
 

--- a/src/cmdlets/Get-GraphApplication.ps1
+++ b/src/cmdlets/Get-GraphApplication.ps1
@@ -29,6 +29,9 @@ function Get-GraphApplication {
         [parameter(parametersetname='name', mandatory=$true)]
         $Name,
 
+        [Alias('MaximumResultCount')]
+        [int32] $First = 0,
+
         [switch] $RawContent,
 
         [String] $Version = $null,
@@ -40,7 +43,7 @@ function Get-GraphApplication {
     )
     Enable-ScriptClassVerbosePreference
 
-    $result = $::.ApplicationHelper |=> QueryApplications $AppId $objectId $Filter $Name $RawContent $Version $null $null $connection
+    $result = $::.ApplicationHelper |=> QueryApplications $AppId $objectId $Filter $Name $RawContent $Version $null $null $connection $null $null $First
 
     $displayableResult = if ( $result ) {
         if ( $RawContent.IsPresent ) {

--- a/src/cmdlets/Get-GraphResource.ps1
+++ b/src/cmdlets/Get-GraphResource.ps1
@@ -96,6 +96,12 @@ This parameter specifies that instead of accessing Microsoft Graph, the command 
 .PARAMETER NoClientRequestId
 This parameter suppresses the automatic generation and submission of the 'client-request-id' header in the request used for troubleshooting with service-side request logs. This parameter is included only to enable complete control over the protocol as there would be very few use cases for not sending the request id.
 
+.PARAMETER NoRequest
+When NoRequest is specified, instead of the command issuing a request to the Graph and returning the response content as command output, no request is issued and the request URI including query parameters rather than the content is emitted as output. This parameter is a useful way to understnd the request URI that would be generated for a given set of parameter options including search filters, and could be used to supply a URI to other Graph clients that could issue the actual request.
+
+.PARAMETER NoSizeWarning
+Specify NoSizeWarning to suppress the warning emitted by the command if 1000 or more items are retrieved by the command and no paging parameters, i.e. First or Skip parameters, were specified. The warning is intended to communicate that returning such a large result set may not have been intended. Use this parameter to ensure that automated scripts do not output the warning when intentionally used on large result sets to return all results.
+
 .OUTPUTS
 The command returns the content of the HTTP response from the Graph endpoint. The result will depend on the documented response of GET requests for the Graph URI. The results are formatted as either deserialized PowerShell objects, or, if the RawContent parameter is also sp ecified, the literal content of the HTTP response. Because Graph responds to requests with JSON except in cases where content types such as images or other media are requested, use of the RawContent parameter will usually result in JSON output.
 
@@ -202,6 +208,8 @@ function Get-GraphResource {
 
         [switch] $NoRequest,
 
+        [switch] $NoSizeWarning,
+
         [string] $ResultVariable = $null
     )
 
@@ -225,6 +233,7 @@ function Get-GraphResource {
             Headers=$Headers
             NoClientRequestId=$NoClientRequestId
             NoRequest=$NoRequest
+            NoSizeWarning=$NoSizeWarning
             First=$pscmdlet.pagingparameters.first
             Skip=$pscmdlet.pagingparameters.skip
             IncludeTotalCount=$pscmdlet.pagingparameters.includetotalcount

--- a/src/cmdlets/Invoke-GraphRequest.ps1
+++ b/src/cmdlets/Invoke-GraphRequest.ps1
@@ -15,6 +15,7 @@
 . (import-script ../common/GraphUtilities)
 . (import-script ../common/GraphAccessDeniedException)
 . (import-script common/QueryHelper)
+. (import-script common/ItemResultHelper)
 . (import-script ../REST/GraphRequest)
 . (import-script ../REST/RequestLog)
 . (import-script ../REST/GraphErrorRecorder)
@@ -632,10 +633,11 @@ function Invoke-GraphRequest {
             if ( $graphResponse -and ( ! $useRawContent ) ) {
                 # Add __ItemContext to decorate the object with its source uri.
                 # Do this as a script method to prevent deserialization
-                $requestUriNoQuery = $request.Uri.GetLeftPart([System.UriPartial]::Path)
-                $ItemContextScript = [ScriptBlock]::Create("[PSCustomObject] @{RequestUri=`"$requestUriNoQuery`"}")
+
+                $itemContext = $::.ItemResultHelper |=> GetItemContext $request.Uri $graphResponse.ODataContext
+
                 $content | foreach {
-                    $_ | add-member -membertype scriptmethod -name __ItemContext -value $ItemContextScript
+                    $::.ItemResultHelper |=> SetItemContext $_ $itemContext
                 }
 
                 $responses += $graphResponse

--- a/src/cmdlets/Invoke-GraphRequest.ps1
+++ b/src/cmdlets/Invoke-GraphRequest.ps1
@@ -634,10 +634,15 @@ function Invoke-GraphRequest {
                 # Add __ItemContext to decorate the object with its source uri.
                 # Do this as a script method to prevent deserialization
 
-                $itemContext = $::.ItemResultHelper |=> GetItemContext $request.Uri $graphResponse.ODataContext
+                $responseItemContext = $::.ItemResultHelper |=> GetItemContext $request.Uri $graphResponse.ODataContext
 
                 $content | foreach {
-                    $::.ItemResultHelper |=> SetItemContext $_ $itemContext
+                    $sourceContext = if ( $_ | gm '@odata.context' -erroraction ignore ) {
+                        $::.ItemResultHelper |=> GetItemContext $request.Uri $_.'@odata.context'
+                    } else {
+                        $responseItemContext
+                    }
+                    $::.ItemResultHelper |=> SetItemContext $_ $sourceContext
                 }
 
                 $responses += $graphResponse

--- a/src/cmdlets/Invoke-GraphRequest.ps1
+++ b/src/cmdlets/Invoke-GraphRequest.ps1
@@ -584,6 +584,7 @@ function Invoke-GraphRequest {
             }
 
             $skipCount = $null
+            $maxResultCount = $null
 
             $content = if ( $graphResponse -and $graphResponse.Entities -ne $null ) {
                 if ( ! $contentTypeData ) {

--- a/src/cmdlets/Invoke-GraphRequest.ps1
+++ b/src/cmdlets/Invoke-GraphRequest.ps1
@@ -35,7 +35,7 @@ The output of the command is typically the Content field of the response as dese
 
 Executing Invoke-GraphRequest will result in a sign-in UX if the Connection object of the current Graph or one explicitly supplied to the command through the Connection parameter does not already have a token associated with it. Once the token is acquired for the Connection object, it is used to issue the request to Graph. Subsequent invocations of this or any other commands in the module that use the same connection will silently use the previously acquired token without a UX, so there will be no additional sign-in UX.
 
-The command also supports paging, since the Graph endpoint can return large result sets in the thousands of objects over HTTP protocol. By default this command returns only the first 10 results in a request. The PowerShell standard paging parameters First and Skip can be used to control which subset of the results to return in a single invocation of Invoke-GraphRequest.
+The command also supports paging, since the Graph endpoint can return large result sets in the thousands of objects over HTTP protocol. By default this command returns only a limited number of results in the request depending on the particular request. The PowerShell standard paging parameters First and Skip can be used to control the number and overall subset of the results to return in a single invocation of Invoke-GraphRequest.
 
 This command, like all commands in this module, uses the Connection object of the current graph by default to determine the Graph endpoint and credentials / permissions of an access token used to communicate to Graph. The current Graph's connection can be changed to use different credentials, permissions, or Graph endpoing by using the Connect-Graph command.
 
@@ -447,8 +447,6 @@ function Invoke-GraphRequest {
         $maxReturnedResults = $null
         $maxResultCount = if ( $pscmdlet.pagingparameters.first -ne $null -and $pscmdlet.pagingparameters.first -lt [Uint64]::MaxValue ) {
             $pscmdlet.pagingparameters.First | tee-object -variable maxReturnedResults
-        } else {
-            10
         }
 
         $skipCount = $firstIndex

--- a/src/cmdlets/Invoke-GraphRequest.ps1
+++ b/src/cmdlets/Invoke-GraphRequest.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019, Adam Edwards
+# Copyright 2020, Adam Edwards
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -77,13 +77,30 @@ The Expand parameter transforms results in a response from identifiers to the fu
 The OrderBy parameter, which is also aliased as 'Sort', indicates that the results returned by the Graph API should be sorted using the key specified as the parameter value. If the Descending parameter is not specified when OrderBy is specified, the values should be sorted in ascending order.
 
 .PARAMETER First
-The First parameter specifies that Graph should only return a specific number of results in the HTTP response. If a request would normally result in 500 items, only the number specified by this parameter would be returned, i.e. the first N results according to the sort order that Graph defaults to or that is specified by this command through the OrderBy parameter. This parameter can be used in conjunction with the Skip parameter to page through results -- First is essentially the page size. By default, Invoke-GraphRequest returns only the first 10 results.
+The First parameter specifies that Graph should only return a specific number of results in the HTTP response. If a request would normally result in 500 items, only the number specified by this parameter would be returned, i.e. the first N results according to the sort order that Graph defaults to or that is specified by this command through the OrderBy parameter.
 
 .PARAMETER Skip
 Skip specifies that Graph should not return the first N results in the HTTP response, i.e. that it should "discard" them. Graph determines the results to throw away after sorting them according to the order Graph defaults to or is specified by this command through the OrderBy parameter. This parameter can be used in conjunction with this First parameter to page through results -- if 20 results were already returned by one or more previous invocations of this command, then by specifying 20 for Skip in the next invocation, Graph will skip past the previously returned results and return the next "page" of results with a page size specified by First.
 
 .PARAMETER Value
 The Value parameter may be used when the result is itself metadata describing some data, such as an image. To obtain the actual data, rather than the metadata, specify Value. This is particularly useful for obtaining pictures for instance, e.g. me/photo.
+
+.PARAMETER Delta
+The Delta parameter specifies that this command should issue a request to get incremental changes for the specified URI. For example, if the caller needs information about new security groups as they are created, they could use this command to periodically issue a query with the URI /groups which would return all currently existing groups, and compare this list to the result from a previous response to the same query. Such an approach is expensive, particularly for tenants with a large number of security groups. To avoid this, use the Delta parameter in the first command invocation. The response will conform to that used when the AsResponseDetail parameter is specified, and will include not just the results in the Content field, but also the fields DeltaToken and DeltaUri. The DeltaUri field can be used any subsequent request to Invoke-GraphRequest -- the response to such a request will include only the data that have changed between the time all data was retrieved from the initial request with Delta specified and now. Because these responses include only the changes, this approach to obtaining the changes to security groups is dramatically more efficient.
+
+.PARAMETER DeltaToken
+This parameter provides a way to request only the incremental changes that would be returned compared to a previous request issued by this command using the Delta parameter. Its value can be obtained from the result of that initial request in the DeltaToken field of its response. When DeltaToken is specified, the URI parameter should simply be the same URI specified in the initial request that used the Delta parameter. Alternatively, the DeltaUri field can be specified as the URI for subsequent requests and the DeltaToken field should not be specified in that case.
+
+.PARAMETER AsResponseDetail
+By default, unless the NoPaging, Delta, or DeltaToken parameters are specified, the ouptut of this command is simply the collection of objects returned from the Graph. Such default output is missing some additional information returned by Graph including the OData context or the next URI to use for incomplete results. The additional output which may include additional type information about the content can be useful for custom processing of incremental delta requests, customized result paging and indication of partial results, and interpretation of the content. The fields of this output are as follows:
+  * Content: contains the equivalent of the output emitted when the AsResponseDetail format is not used. The DeltaUri field contains
+  * ContextUri (optional): contains the OData context URI
+  * DeltaUri (optional): a URI that can be used with this command to get only incremental changes from this response. Only returned once all data are processed for a request issued with the Delta parameter
+  * AbsoluteDeltaUri (optional): Same as DeltaUri, but uses an absolute URI format that can only be used as the Invoke-GraphRequest Uri parameter when the AbsoluteUri parameter is specified
+  * DeltaToken (optional): a state token that can be used with this command to get only incremental changes from this response, and returned only when DeltaUri would be returned
+  * NextUri (optional): a URI used to retrieve the next page of results, empty if there are no next results. This can be used to do custom paging, or to indicate that there are more results left to retrieve.
+  * AbsoluteNextUri (optional): Same as NextUri, but uses an absolute URI format that can only be as the Invoke-GraphRequest Uri parameter when the AbsoluteUri parameter is specified
+  * Responses: This contains the actual HTTP protocol responses from Graph along with additional details about each response. There will always be at least one response if the command is successful, and more than one of Invoke-GraphRequest makes additional requests as part of paging through partial responses returned by Graph
 
 .PARAMETER OutputFilePrefix
 The OutputFilePrefix parameter specifies that rather than emitting the results to the PowerShell pipeline, each result should be written to a file name prefixed with the value of the OutputFilePrefix. The parameter value may be a path to a directory, or simply a name with no path separator. If there is more than one item in the result, the base file name for that result will end with a unique integer identifier within the result set. The file extension will be 'json' unless the result is of another content type, in which case the command will attempt to determine the extension from the content type returned in the HTTP response. If the content type cannot be determined, then the file extension will be '.dat'.
@@ -115,14 +132,17 @@ By default the URIs specified by the Uri parameter are relative to the current G
 .PARAMETER RawContent
 This parameter specifies that the command should return results exactly in the format of the HTTP response from the Graph endpoint, rather than the default behavior where the objects are deserialized into PowerShell objects. Graph returns objects as JSON except in cases where content types such as media are being requested, so use of this parameter will generally cause the command to return JSON output.
 
-.PARAMETER IncludeFullResponse
-This parameter specifies that the output of this command should be structured as an object with a reference to the output typically returned when this parameter is not specified, along with the responses from the service. This parameter may be replaced in the future with a more generic interface.
-
 .PARAMETER AADGraph
 This parameter specifies that instead of accessing Microsoft Graph, the command should make requests against Azure Active Directory Graph (AAD Graph). Note that most functionality of this command and other commands in the module is not compatible with AAD Graph; this parameter may be deprecated in the future.
 
 .PARAMETER NoClientRequestId
 This parameter suppresses the automatic generation and submission of the 'client-request-id' header in the request used for troubleshooting with service-side request logs. This parameter is included only to enable complete control over the protocol as there would be very few use cases for not sending the request id.
+
+.PARAMETER NoPaging
+By default, when Invoke-GraphRequest issues a request and receives a response indicating that an incomplete result set for the request has been returned, the command issues additional requests to retrieve the full set of data until the Graph indicates that all data have been returned. When the NoPaging parameter is specified, Invoke-GraphCommand issues only one request. When NoPaging is specified, instead of directly returning the content of the response for Graph, the output result uses the format as that specified by the AsResponseDetail parameter; the content is exposed in the Data property of the result object.
+
+.PARAMETER NoRequest
+When NoRequest is specified, instead of the command issuing a request to the Graph and returning the response content as command output, no request is issued and the request URI including query parameters rather than the content is emitted as output. This parameter is a useful way to understnd the request URI that would be generated for a given set of parameter options including search filters, and could be used to supply a URI to other Graph clients that could issue the actual request.
 
 .OUTPUTS
 TThe command returns the content of the HTTP response from the Graph endpoint. The result will depend on the documented response for the specified HTTP method parameter for the Graph URI. The results are formatted as either deserialized PowerShell objects, or, if the RawContent parameter is also specified, the literal content of the HTTP response. Because Graph responds to requests with JSON except in cases where content types such as images or other media are requested, use of the RawContent parameter will usually result in JSON output.
@@ -256,6 +276,12 @@ function Invoke-GraphRequest {
 
         [Switch] $Value,
 
+        [Switch] $Delta,
+
+        [string] $DeltaToken,
+
+        [Switch] $AsResponseDetail,
+
         [String] $OutputFilePrefix = $null,
 
         [String] $Query = $null,
@@ -280,10 +306,12 @@ function Invoke-GraphRequest {
 
         [switch] $RawContent,
 
-        [switch] $IncludeFullResponse,
-
         [parameter(parametersetname='AADGraphNewConnection', mandatory=$true)]
         [switch] $AADGraph,
+
+        [int32] $PageSizePreference,
+
+        [switch] $NoPaging,
 
         [switch] $NoClientRequestId,
 
@@ -312,12 +340,16 @@ function Invoke-GraphRequest {
 
         if ( $Query ) {
             if ( $Search -or $Filter -or $Select -or $OrderBy ) {
-                throw [ArgumentException]::new("'Filter', 'Search', 'OrderBy',  and 'Select' parameters may not specified when the 'Query' parameter is specified")
+                throw [ArgumentException]::new("'Filter', 'Search', 'OrderBy', and 'Select' parameters may not specified when the 'Query' parameter is specified")
             }
         }
 
         if ( $Descending.IsPresent -and ! $OrderBy ) {
             throw [ArgumentException]::new("'Descending' option was specified without 'OrderBy'")
+        }
+
+        if ( $Delta.IsPresent -and $DeltaToken ) {
+            throw [ArgumentException]::new("Only one of the Delta and DeltaToken parameters may be specified")
         }
 
         $orderQuery = if ( $OrderBy ) {
@@ -417,6 +449,12 @@ function Invoke-GraphRequest {
 
         $skipCount = $firstIndex
         $results = @()
+
+        $deltaLink = $null
+        $nextLink = $null
+        $contextUri = $null
+
+        $responses = @()
     }
 
     process {
@@ -500,6 +538,13 @@ function Invoke-GraphRequest {
 
         $logger = $::.RequestLog |=> GetDefault
 
+        $startDelta = $Delta.IsPresent
+        $initialDeltaToken = $DeltaToken
+
+        $isDeltaUri = ( $::.GraphUtilities |=> IsDeltaUri $Uri )
+
+        $isDeltaRequest = $Delta.IsPresent -or $DeltaToken -or $isDeltaUri
+
         while ( $graphRelativeUri -ne $null -and ($graphRelativeUri.tostring().length -gt 0) -and ($maxResultCount -eq $null -or $results.length -lt $maxResultCount) ) {
             if ( $graphType -eq ([GraphType]::AADGraph) ) {
                 $graphRelativeUri = $graphRelativeUri, "api-version=$apiVersion" -join '?'
@@ -512,10 +557,10 @@ function Invoke-GraphRequest {
                     $null
                 }
 
-                $request = new-so GraphRequest $graphConnection $graphRelativeUri $Method $Headers $currentPageQuery $ClientRequestId $NoClientRequestId.IsPresent $NoRequest.IsPresent
+                $request = new-so GraphRequest $graphConnection $graphRelativeUri $Method $Headers $currentPageQuery $ClientRequestId $NoClientRequestId.IsPresent $NoRequest.IsPresent ( $startDelta -and ! $isDeltaUri ) $initialDeltaToken $PageSizePreference
                 $request |=> SetBody $Body
                 try {
-                    $request |=> Invoke $skipCount -logger $logger
+                    $request |=> Invoke $skipCount $maxResultCount -logger $logger
                 } catch [System.Net.WebException] {
                     $statusCode = if ( $_.exception.response | gm statuscode -erroraction ignore ) {
                         $_.exception.response.statuscode
@@ -541,9 +586,20 @@ function Invoke-GraphRequest {
                     $contentTypeData = $graphResponse.RestResponse.ContentTypeData
                 }
 
-                $graphRelativeUri = $graphResponse.Nextlink
+                $nextLink = $graphResponse.NextLink
+                $deltaLink = $graphResponse.DeltaLink
+                if ( ! $contextUri ) {
+                    $contextUri = $graphResponse.ODataContext
+                }
 
-                if (! $useRawContent) {
+                $graphRelativeUri = if ( ! $NoPaging.IsPresent ) {
+                    $nextLink
+                }
+
+                $startDelta = $false
+                $initialDeltaToken = $null
+
+                if ( ! $useRawContent ) {
                     $entities = if ( $graphResponse.entities -is [Object[]] -and $graphResponse.entities.length -eq 1 ) {
                         @([PSCustomObject] $graphResponse.entities)
                     } elseif ($graphResponse.entities -is [HashTable]) {
@@ -561,11 +617,7 @@ function Invoke-GraphRequest {
                     }
                     $entities
                 } else {
-                    if ( $IncludeFullResponse.IsPresent -and ! $outputFilePrefix) {
-                        __ToResponseWithObject ($graphResponse |=> Content) $graphResponse
-                    } else {
-                        $graphResponse |=> Content
-                    }
+                    $graphResponse |=> Content
                 }
             } else {
                 $graphRelativeUri = $null
@@ -582,6 +634,8 @@ function Invoke-GraphRequest {
                 $content | foreach {
                     $_ | add-member -membertype scriptmethod -name __ItemContext -value $ItemContextScript
                 }
+
+                $responses += $graphResponse
             }
 
             $results += $content
@@ -603,17 +657,27 @@ function Invoke-GraphRequest {
 
             $PSCmdlet.PagingParameters.NewTotalCount($count,  $accuracy)
         }
-
-        $filteredResults = if ( $maxReturnedResults ) {
-            $results | select -first $maxReturnedResults
-        } else {
-            $results
-        }
     }
 
     end {
-        if ( ! $OutputFilePrefix ) {
+        $filteredResults = if ( ! $useRawContent ) {
+            $results | where { $_ | gm id -erroraction ignore }
+        } else {
+            $results
+        }
+
+        $filteredResults = if ( $maxReturnedResults ) {
+            $filteredResults | select -first $maxReturnedResults
+        } else {
             $filteredResults
+        }
+
+        if ( ! $OutputFilePrefix ) {
+            if ( ! $useRawContent -and ( $AsResponseDetail.IsPresent -or $isDeltaRequest -or $NoPaging.IsPresent ) ) {
+                $::.ItemResultHelper |=> GetResponseDetail $filteredResults $contextUri $nextLink $deltaLink $responses
+            } else {
+                $filteredResults
+            }
         } else {
             $enumerableResults = if ( ! $contentTypeData['charset'] ) {
                 $byteResults = @($null, $null)

--- a/src/cmdlets/Invoke-GraphRequest.ps1
+++ b/src/cmdlets/Invoke-GraphRequest.ps1
@@ -93,7 +93,7 @@ This parameter provides a way to request only the incremental changes that would
 
 .PARAMETER AsResponseDetail
 By default, unless the NoPaging, Delta, or DeltaToken parameters are specified, the ouptut of this command is simply the collection of objects returned from the Graph. Such default output is missing some additional information returned by Graph including the OData context or the next URI to use for incomplete results. The additional output which may include additional type information about the content can be useful for custom processing of incremental delta requests, customized result paging and indication of partial results, and interpretation of the content. The fields of this output are as follows:
-  * Content: contains the equivalent of the output emitted when the AsResponseDetail format is not used. The DeltaUri field contains
+  * Content: contains the equivalent of the output emitted when the AsResponseDetail format is not used.
   * ContextUri (optional): contains the OData context URI
   * DeltaUri (optional): a URI that can be used with this command to get only incremental changes from this response. Only returned once all data are processed for a request issued with the Delta parameter
   * AbsoluteDeltaUri (optional): Same as DeltaUri, but uses an absolute URI format that can only be used as the Invoke-GraphRequest Uri parameter when the AbsoluteUri parameter is specified
@@ -134,6 +134,9 @@ This parameter specifies that the command should return results exactly in the f
 
 .PARAMETER AADGraph
 This parameter specifies that instead of accessing Microsoft Graph, the command should make requests against Azure Active Directory Graph (AAD Graph). Note that most functionality of this command and other commands in the module is not compatible with AAD Graph; this parameter may be deprecated in the future.
+
+.PARAMETER PageSizePreference
+This parameter directs the command to issues requests that instruct the Graph API to return a specific maximum number of items in each page of results. This parameter will only take effect if Graph honors it for the particular request.
 
 .PARAMETER NoClientRequestId
 This parameter suppresses the automatic generation and submission of the 'client-request-id' header in the request used for troubleshooting with service-side request logs. This parameter is included only to enable complete control over the protocol as there would be very few use cases for not sending the request id.

--- a/src/cmdlets/Invoke-GraphRequest.tests.ps1
+++ b/src/cmdlets/Invoke-GraphRequest.tests.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019, Adam Edwards
+# Copyright 2020, Adam Edwards
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/cmdlets/New-GraphApplication.ps1
+++ b/src/cmdlets/New-GraphApplication.ps1
@@ -138,7 +138,7 @@ function New-GraphApplication {
     }
 
     if ( ! $SkipTenantRegistration.IsPresent ) {
-        $newAppRegistration |=> Register $true (! $NoConsent.IsPresent) $ConsentForAllUsers.IsPresent $UserIdToConsent $DelegatedUserPermissions $ApplicationPermissions | out-null
+        $newAppRegistration |=> Register $true (! $NoConsent.IsPresent) $UserIdToConsent $ConsentForAllUsers.IsPresent $DelegatedUserPermissions $ApplicationPermissions | out-null
     }
 
     $newApp

--- a/src/cmdlets/Test-Graph.ps1
+++ b/src/cmdlets/Test-Graph.ps1
@@ -122,8 +122,10 @@ function Test-Graph {
     $request = new-so RESTRequest $pingUri
     $logEntry = if ( $logger ) { $logger |=> NewLogEntry $null $request }
 
-    try {
-        $response = $request |=> Invoke -logEntry $logEntry
+    $response = try {
+        $request |=> Invoke -logEntry $logEntry
+    } catch {
+        throw
     } finally {
         if ( $logEntry ) { $logger |=> CommitLogEntry $logEntry }
     }

--- a/src/cmdlets/common/ApplicationHelper.ps1
+++ b/src/cmdlets/common/ApplicationHelper.ps1
@@ -47,7 +47,7 @@ ScriptClass ApplicationHelper {
             $this.keyFormatter |=> DeserializedGraphObjectToDisplayableObject $remappedObject
         }
 
-        function QueryApplications($appId, $objectId, $odataFilter, $name, [object] $rawContent, $version, $permissions, $cloud, $connection, $select = '*', $queryMethod = 'GET') {
+        function QueryApplications($appId, $objectId, $odataFilter, $name, [object] $rawContent, $version, $permissions, $cloud, $connection, $select, $queryMethod, [int32] $maxResultCount) {
             $apiVersion = if ( $Version ) {
                 $Version
             } else {
@@ -66,19 +66,35 @@ ScriptClass ApplicationHelper {
                 $uri += "/$ObjectId"
             }
 
+            $targetSelect = if ( $select ) {
+                $select
+            } else {
+                '*'
+            }
+
             $requestArguments = @{
                 RawContent = $rawContent
                 Filter = $filter
                 Permissions = $permissions
-                Select = $select
+                Select = $targetSelect
             }
 
             if ( $connection ) {
                 $requestArguments['Connection'] = $connection
             }
 
+            if ( $maxResultCount ) {
+                $requestArguments['First'] = $maxResultCount
+            }
+
+            $method = if ( $queryMethod ) {
+                $queryMethod
+            } else {
+                'GET'
+            }
+
             write-verbose "Querying for applications at version $apiVersion' with uri '$uri, filter '$filter', select '$select'"
-            Invoke-GraphRequest -Method $queryMethod -Uri $uri @requestArguments -version $apiVersion
+            Invoke-GraphRequest -Method $method -Uri $uri @requestArguments -version $apiVersion
         }
     }
 }

--- a/src/cmdlets/common/ItemResultHelper.ps1
+++ b/src/cmdlets/common/ItemResultHelper.ps1
@@ -79,13 +79,13 @@ ScriptClass ItemResultHelper -ArgumentList $__DefaultResultVariable {
         }
 
         function GetItemContext([Uri] $requestUri, $contextUri) {
-            $requestUriNoQuery = $requestUri.GetLeftPart([System.UriPartial]::Path)
+            $requestUriNoQuery = $requestUri.GetLeftPart([System.UriPartial]::Path).replace("'", "''")
             $responseContext = new-so ResponseContext $requestUriNoQuery $contextUri |=> ToPublicContext
 
             # Add __ItemContext to decorate the object with its source uri.
             # Do this as a script method to prevent deserialization
-            $contextGraphUri = $responseContext.GraphUri
-            $contextTypelessGraphUri = $responseContext.TypelessGraphUri
+            $contextGraphUri = if ( $responseContext.GraphUri ) { $responseContext.GraphUri.replace("'", "''") }
+            $contextTypelessGraphUri = if ( $responseContext.TypelessGraphUri ) { $responseContext.TypelessGraphUri.replace("'", "''") }
             $contextTypeCast = $responseContext.TypeCast
             $contextIsEntity = $responseContext.IsEntity
             $contextIsDeltaLink = $responseContext.IsNewLink -or $responseContext.IsDeletedLink

--- a/src/cmdlets/common/ItemResultHelper.ps1
+++ b/src/cmdlets/common/ItemResultHelper.ps1
@@ -91,7 +91,10 @@ ScriptClass ItemResultHelper -ArgumentList $__DefaultResultVariable {
             $contextIsDeltaLink = $responseContext.IsNewLink -or $responseContext.IsDeletedLink
             $contextIsDelta = $responseContext.IsDelta -or $responseContext.IsDeletedEntity -or $contextIsDeltaLink
             $contextIsDeltaDeleted = $responseContext.IsDeletedLink -or $responseContext.IsDeletedEntity
-            $contextcontextUri = $contextUri
+            $contextIsCollectionMember = $responseContext.IsCollectionMember
+            $contextcontextUri = if ( $contextUri ) {
+                $contextUri.tostring().replace("'", "''")
+            }
 
             $contextGraphUriString = if ( $contextGraphUri ) { "'$contextGraphUri'" } else { '$null' }
             $contextTypelessGraphUriString = if ( $contextTypelessGraphUri ) { "'$contextTypelessGraphUri'" } else { '$null' }
@@ -100,6 +103,7 @@ ScriptClass ItemResultHelper -ArgumentList $__DefaultResultVariable {
             $contextIsDeltaLinkString = if ( $contextIsDeltaLink ) { '$true' } else { '$false' }
             $contextIsDeltaString = if ( $contextIsDelta ) { '$true' } else { '$false' }
             $contextIsDeltaDeletedString = if ( $contextIsDeltaDeleted ) { '$true' } else { '$false' }
+            $contextIsCollectionMemberString = if ( $contextIsCollectionMember ) { '$true' } else { '$false' }
             $contextContextUriString = if ( $contextContextUri ) { "'$contextContextUri'" } else { '$null' }
 
             $scriptText = @"
@@ -113,8 +117,10 @@ ScriptClass ItemResultHelper -ArgumentList $__DefaultResultVariable {
                     IsDelta=$contextIsDeltaString
                     IsDeltaLink=$contextIsDeltaLinkString
                     IsDeltaDeleted=$contextIsDeltaDeletedString
+                    IsCollectionMember=$contextIsCollectionMemberString
                 }
 "@
+
             [ScriptBlock]::Create($scriptText)
         }
 

--- a/src/common/GraphUtilities.ps1
+++ b/src/common/GraphUtilities.ps1
@@ -286,15 +286,21 @@ ScriptClass GraphUtilities {
             $uri.OriginalString.substring(0, $uri.OriginalString.length - $uriQueryLength)
         }
 
-        function GetAbstractUriFromItem($item, $assumeEntity, $explicitId) {
-            $itemContext = GetItemContext $item
+        function GetOptionalTypeFromResponseObject($object) {
+            if ( $object | gm '@odata.type' -erroraction ignore ) {
+                $object.'@odata.type'.trimstart('#')
+            }
+        }
 
-            if ( $itemContext ) {
-                $id = if ( $item | gm id -erroraction ignore ) {
-                    $item.id
+        function GetAbstractUriFromResponseObject($object, $assumeEntity, $explicitId) {
+            $objectContext = GetResponseObjectContext $object
+
+            if ( $objectContext ) {
+                $id = if ( $object | gm id -erroraction ignore ) {
+                    $object.id
                 }
 
-                $isEntity = $itemContext.IsEntity -or $itemContext.IsDelta
+                $isEntity = $objectContext.IsEntity -or $objectContext.IsDelta
                 $idNotNeededOrInItem = $assumeEntity -or ! $isEntity
 
                 $targetId = if ( $id ) {
@@ -303,7 +309,7 @@ ScriptClass GraphUtilities {
                     $explicitId
                 }
 
-                $typelessUri = $itemContext.TypelessGraphUri
+                $typelessUri = $objectContext.TypelessGraphUri
 
                 # If we have an id, we'll return something if it's known to be entity,
                 # if we were told to assume that its an entity
@@ -330,9 +336,9 @@ ScriptClass GraphUtilities {
             }
         }
 
-        function GetItemContext($item) {
-            if ( $item | gm -membertype scriptmethod __ItemContext -erroraction ignore ) {
-                $item.__ItemContext()
+        function GetResponseObjectContext($object) {
+            if ( $object | gm -membertype scriptmethod __ItemContext -erroraction ignore ) {
+                $object.__ItemContext()
             }
         }
     }

--- a/src/common/GraphUtilities.ps1
+++ b/src/common/GraphUtilities.ps1
@@ -316,10 +316,12 @@ ScriptClass GraphUtilities {
                 $isEntity = $objectContext.IsEntity -or $objectContext.IsDelta
                 $idNotNeededOrInItem = $assumeEntity -or ! $isEntity
 
-                $targetId = if ( $id ) {
-                    $id
-                } else {
-                    $explicitId
+                $targetId = if ( $objectContext.IsCollectionMember ) {
+                    if ( $id ) {
+                        $id
+                    } else {
+                        $explicitId
+                    }
                 }
 
                 $typelessUri = $objectContext.TypelessGraphUri
@@ -337,7 +339,7 @@ ScriptClass GraphUtilities {
                         }
                     }
                     # If there is no typeless URI, we will return nothing
-                } elseif ( ! $idNotNeededOrInItem ) {
+                } elseif ( ! $idNotNeededOrInItem -or ! $objectContext.IsCollectionMember ) {
                     $typelessUri
                 }
 

--- a/src/common/GraphUtilities.ps1
+++ b/src/common/GraphUtilities.ps1
@@ -292,6 +292,19 @@ ScriptClass GraphUtilities {
             }
         }
 
+        function ParseTypeName([string] $typeName) {
+            $isCollection = $false
+
+            $scalarQualifiedTypeName = if ($typeName -match 'Collection\((?<typename>.+)\)') {
+                $isCollection = $true
+                $matches.typename
+            } else {
+                $typeName
+            }
+
+            [PSCustomObject]@{TypeName=$scalarQualifiedTypeName;IsCollection=$isCollection}
+        }
+
         function GetAbstractUriFromResponseObject($object, $assumeEntity, $explicitId) {
             $objectContext = GetResponseObjectContext $object
 

--- a/src/common/GraphUtilities.tests.ps1
+++ b/src/common/GraphUtilities.tests.ps1
@@ -291,5 +291,38 @@ Describe 'GraphUtilities methods' {
             $::.GraphUtilities |=> GetAbstractUriFromResponseObject $item | Should Be $null
         }
 
+        It 'Should handle segments of the context URI that have single quotes' {
+            $requestUri = 'https://graph.microsoft.com/v1.0/users/userid/drive/root'
+            $contextUri = "https://graph.microsoft.com/v1.0/`$metadata#users('userid')/drive/root/`$entity"
+
+            $item = (NewTestItemWithContext $requestUri $contextUri userid)
+            $itemWithContext = $item.__ItemContext()
+
+            $itemWithContext.GraphUri | Should Be "/users/userid/drive/root"
+            $itemWithContext.TypelessGraphUri | Should Be "/users/userid/drive/root"
+            $itemWithContext.ContextUri | Should Be $contextUri
+            $itemWithContext.RequestUri | Should Be $requestUri
+            $itemWithContext.TypeCast | Should Be $null
+            $itemWithContext.IsEntity | Should Be $true
+
+            $::.GraphUtilities |=> GetAbstractUriFromResponseObject $item $true | Should Be "/users/userid/drive/root"
+        }
+
+        It 'Should handle entities resulting from a navigation property that are not members of a collection rooted at a singleton' {
+            $requestUri = 'https://graph.microsoft.com/v1.0/me/drive/root'
+            $contextUri = "https://graph.microsoft.com/v1.0/`$metadata#users('userid')/drive/root/`$entity"
+
+            $item = (NewTestItemWithContext $requestUri $contextUri userid)
+            $itemWithContext = $item.__ItemContext()
+
+            $itemWithContext.GraphUri | Should Be "/users/userid/drive/root"
+            $itemWithContext.TypelessGraphUri | Should Be "/users/userid/drive/root"
+            $itemWithContext.ContextUri | Should Be $contextUri
+            $itemWithContext.RequestUri | Should Be $requestUri
+            $itemWithContext.TypeCast | Should Be $null
+            $itemWithContext.IsEntity | Should Be $true
+
+            $::.GraphUtilities |=> GetAbstractUriFromResponseObject $item $false | Should Be "/users/userid/drive/root"
+        }
     }
 }

--- a/src/common/GraphUtilities.tests.ps1
+++ b/src/common/GraphUtilities.tests.ps1
@@ -95,7 +95,7 @@ Describe 'GraphUtilities methods' {
         }
     }
 
-    Context "When retrieving information about the request context from a response item returned by the Graph service through GetAbstractUriFromItem" {
+    Context "When retrieving information about the request context from a response item returned by the Graph service through GetAbstractUriFromResponseObject" {
         function NewTestItemWithContext($requestUri, $contextUri, $id) {
             # The id is used to populate the id field of the object,
             # which must be present unless it is not selected or the object
@@ -129,7 +129,7 @@ Describe 'GraphUtilities methods' {
             $itemWithContext.TypeCast | Should Be $null
             $itemWithContext.IsEntity | Should Be $true
 
-            $::.GraphUtilities |=> GetAbstractUriFromItem $item | Should Be '/users/userid'
+            $::.GraphUtilities |=> GetAbstractUriFromResponseObject $item | Should Be '/users/userid'
         }
 
         It 'Should return null when the request URI specified an id from an entity set and the assumeEntity option is true' {
@@ -146,7 +146,7 @@ Describe 'GraphUtilities methods' {
             $itemWithContext.TypeCast | Should Be $null
             $itemWithContext.IsEntity | Should Be $true
 
-            $::.GraphUtilities |=> GetAbstractUriFromItem $item $true | Should Be '/users/userid'
+            $::.GraphUtilities |=> GetAbstractUriFromResponseObject $item $true | Should Be '/users/userid'
         }
 
         It 'Should return a URI similar to the request URI with an additional id segment when the request URI specified an entity set and assumeEntity is true' {
@@ -163,7 +163,7 @@ Describe 'GraphUtilities methods' {
             $itemWithContext.TypeCast | Should Be $null
             $itemWithContext.IsEntity | Should Be $false
 
-            $::.GraphUtilities |=> GetAbstractUriFromItem $item $true | Should Be '/users/userid'
+            $::.GraphUtilities |=> GetAbstractUriFromResponseObject $item $true | Should Be '/users/userid'
         }
 
         It 'Should return a URI similar to the request URI with an additional id segment when the request URI specified an entity set and assumeEntity is true and a default id is specified and the response object does not have an id' {
@@ -181,7 +181,7 @@ Describe 'GraphUtilities methods' {
             $itemWithContext.TypeCast | Should Be $null
             $itemWithContext.IsEntity | Should Be $false
 
-            $::.GraphUtilities |=> GetAbstractUriFromItem $item $true myoverrideid | Should Be '/users/myoverrideid'
+            $::.GraphUtilities |=> GetAbstractUriFromResponseObject $item $true myoverrideid | Should Be '/users/myoverrideid'
         }
 
         It 'Should return null when the request URI specified an entity set and assumeEntity is false but a default id is specified because the response object does not have an id' {
@@ -199,7 +199,7 @@ Describe 'GraphUtilities methods' {
             $itemWithContext.TypeCast | Should Be $null
             $itemWithContext.IsEntity | Should Be $false
 
-            $::.GraphUtilities |=> GetAbstractUriFromItem $item $false myoverrideid | Should Be $null
+            $::.GraphUtilities |=> GetAbstractUriFromResponseObject $item $false myoverrideid | Should Be $null
         }
 
         It 'Should return null when the request URI specified an entity and assumeEntity is true but a default id is not specified and the response object does not have an id' {
@@ -217,7 +217,7 @@ Describe 'GraphUtilities methods' {
             $itemWithContext.TypeCast | Should Be $null
             $itemWithContext.IsEntity | Should Be $true
 
-            $::.GraphUtilities |=> GetAbstractUriFromItem $item $true | Should Be $null
+            $::.GraphUtilities |=> GetAbstractUriFromResponseObject $item $true | Should Be $null
         }
 
         It 'Should return Should return a URI similar to the request URI when the request URI specified an id for an entity when and assumeEntity is $false and a default id is specified and the response object does not have an id and an explicit override id is supplied (this is used to complete the uri)' {
@@ -235,7 +235,7 @@ Describe 'GraphUtilities methods' {
             $itemWithContext.TypeCast | Should Be $null
             $itemWithContext.IsEntity | Should Be $true
 
-            $::.GraphUtilities |=> GetAbstractUriFromItem $item $false userid | Should Be '/users/userid'
+            $::.GraphUtilities |=> GetAbstractUriFromResponseObject $item $false userid | Should Be '/users/userid'
         }
 
         It 'Should return Should return a URI similar to the request URI when the request URI specified an id for an entity when and assumeEntity is $true and a default id is specified and the response object does not have an id and an explicit override id is supplied (this is used to complete the uri)' {
@@ -253,7 +253,7 @@ Describe 'GraphUtilities methods' {
             $itemWithContext.TypeCast | Should Be $null
             $itemWithContext.IsEntity | Should Be $true
 
-            $::.GraphUtilities |=> GetAbstractUriFromItem $item $true userid | Should Be '/users/userid'
+            $::.GraphUtilities |=> GetAbstractUriFromResponseObject $item $true userid | Should Be '/users/userid'
         }
 
         It 'Should return $null when the request URI specified an entity set and assumeEntity is set to false and no id override is specified' {
@@ -270,7 +270,7 @@ Describe 'GraphUtilities methods' {
             $itemWithContext.TypeCast | Should Be $null
             $itemWithContext.IsEntity | Should Be $false
 
-            $::.GraphUtilities |=> GetAbstractUriFromItem $item $false | Should Be $null
+            $::.GraphUtilities |=> GetAbstractUriFromResponseObject $item $false | Should Be $null
         }
 
         It 'Should return the entity set when the request URI specified an entity set and assumeEntity is true and the response object does not have an id and no override is specified' {
@@ -288,7 +288,7 @@ Describe 'GraphUtilities methods' {
             $itemWithContext.TypeCast | Should Be $null
             $itemWithContext.IsEntity | Should Be $false
 
-            $::.GraphUtilities |=> GetAbstractUriFromItem $item | Should Be $null
+            $::.GraphUtilities |=> GetAbstractUriFromResponseObject $item | Should Be $null
         }
 
     }

--- a/src/common/ResponseContext.ps1
+++ b/src/common/ResponseContext.ps1
@@ -1,0 +1,453 @@
+# Copyright 2020, Adam Edwards
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This implementation parses the OData context response from the Graph service.
+# It is based on the specification for OData context URL:
+#
+#    http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_ContextURL
+#
+# Note that it doesn't handle all of the cases covered there, just those necessary to
+# reliably implement capabilities required by this module, most notably:
+#
+#   * Determining whether a response corresponds to an entity or collection of entities
+#   * For an entity or collection of entities, is there a canonical URI?
+#   * If the entity or collection being cast to a specific type, and what is that type?
+#   * What properties were projected for the response?
+#
+# One assumption that consumers should make of this data is that it is not 100% reliable --
+# services have been known to not always populate the context, or to render it incorrectly.
+# As a a result, consumers should consider a reasonable fallback behavior if the data are not
+# present when expected, and should also cross-check it against more reliable sources such as
+# service API metadata if it is available and again adopt a fallback posture. It is advisable
+# to restrict use of this information to scenarios where it is absolutely essential to
+# implement a feature, and to have reasonable behaviors and documented expectations for
+# cases when it is inaccurate.
+#
+# For example, features that need to know the derived type
+# in a response can only get this information from odata context in some cases. A fallback
+# could be to assume the base type described in metadata and to use that base type information
+# to inform functionality. This may result in limited functionality for users compared to
+# if the derived type were known, but mitigations could include
+#
+#   * If it's possible to know that derived types exist by analyzing metadata, a warning
+#     could be given to users to notify that some functionality may be missing
+#   * Users could have the option of specifying an explicit type based on their scenario
+#     knowledge to force tooling to adopt the right behavior.
+#
+# Ideally the context URL would become as reliable a part of a Graph service as the aspects
+# that return actual data and operational behavior. A more explicit behavior rather than
+# document-based context URL could simplify this greatly and would avoid the need to adhere
+# to the contract built up over time around the current context URL specification.
+
+ScriptClass ResponseContext {
+    $RequestUrl = $null
+    $ContextUrl = $null
+    $Root = $null
+    $GraphUri = $null
+    $TypelessGraphuri = $null
+    $AbsoluteGraphUri = $null
+    $TypeCast = $null
+    $ExpandedProperties = $null
+    $SelectedProperties = $null
+    $IsReference = $false
+    $IsEntity = $false
+    $IsDelta = $false
+    $IsNewLink = $false
+    $IsDeletedLink = $false
+    $IsDeletedEntity = $false
+    $isParsed = $false
+
+    $publicMap = @{
+        RequestUrl = $null
+        ContextUrl = $null
+        Root = $null
+        GraphUri = $null
+        TypelessGraphUri = $null
+        AbsoluteGraphUri = $null
+        TypeCast = $null
+        SelectedProperties = $null
+        ExpandedProperties = $null
+        IsReference = $false
+        IsEntity = $false
+        IsDelta = $false
+        IsNewLink = $false
+        IsDeletedLink = $false
+        IsDeletedEntity = $false
+    }
+
+    function __initialize([Uri] $requestUrl, [Uri] $contextUrl) {
+        if ( ! $requestUrl -and ! $contextUrl ) {
+            throw [ArgumentException]::new('One of requestUrl or contextUrl must not be $null')
+        }
+
+        $this.requestUrl = $requestUrl
+        $this.contextUrl = $contextUrl
+    }
+
+    function GetMetadataUri {
+        __Parse
+        $this.GraphUri
+    }
+
+    function ToPublicContext {
+        __Parse
+
+        $result = @{}
+        $this.publicMap.keys | foreach {
+            $target = $this.publicMap[$_]
+
+            if ( ! $target ) {
+                $target = $_
+            }
+            $result.Add($target, $this.$target)
+        }
+
+        [PSCustomObject] $result
+    }
+
+    function __Parse {
+        if ( ! $this.isParsed ) {
+            $context = @{}
+
+            if ( $this.contextUrl ) {
+                $contextFragment = $this.contextUrl.Fragment.trimstart('#')
+                __ParseContextFragment $contextFragment.trimend('/') $context
+
+                if ( $context['GraphUri'] ) {
+                    $version = if ( $this.contextUrl.segments.length -ge 2 ) {
+                        $this.contextUrl.segments[1].trimend('/')
+                    }
+
+                    $absoluteUri = $this.contextUrl.Scheme + "://" + $this.contextUrl.Host
+                    if ( $version ) {
+                        $absoluteUri += '/' + $version + $context.GraphUri
+                    }
+                    $context.Add('AbsoluteGraphUri', $absoluteUri.trimend('/'))
+                }
+            } else {
+                $segments = $this.requestUrl.Segments
+                if ( $segments.length -gt 2 ) {
+                    $context['GraphUri'] = $this.GraphUri + '/' + ( ( $segments[2..($segments.length - 1)] ).trimend('/') -join '/' )
+                    $context['TypelessGraphUri'] = $context['GraphUri']
+                    if ( $context['GraphUri'] ) {
+                        $context['AbsoluteGraphUri'] = $this.requestUrl
+                    }
+                    $context['Root'] = $segments[2]
+                } else {
+                    throw [ArgumentExeption]::new("Request URL '$($this.RequestUrl)' is not a valid Graph URI'")
+                }
+            }
+
+            $context.keys | foreach {
+                $this.$_ = $context[$_]
+            }
+
+            $this.isParsed = $true
+        }
+    }
+
+    function __ParseContextFragment($fragment, [HashTable] $context) {
+        $rawFragmentSegments = , $fragment -split '/'
+
+        $fragmentSegments = __NormalizeSegments $rawFragmentSegments
+
+        $fragmentSegmentsIndex = 0
+
+        $segments = @()
+
+        $hasTypeCastOnlySegment = $false
+
+        $context['GraphUri'] = $null
+        $context['TypelessGraphUri'] = $null
+
+        for ($fragmentSegmentIndex = 0; $fragmentSegmentIndex -lt $fragmentSegments.length; $fragmentSegmentIndex++ ) {
+            $segment = $fragmentSegments[$fragmentSegmentIndex]
+
+            if ( $segment -eq '$ref' ) {
+                # Note that references are considered "unstable" -- we don't have type information
+                # about the object being referenced, so callers should not interpret this as an object
+                # that can be reliably addressed, i.e. it is not a physical location.
+                # Traversing this would be like traversing a symbolic link, and would result in the use
+                # of a non-canonical path. In summary, any parsed information cannot be used to
+                # create a canonical path. In any event, the service is unlikely to return very much context
+                # for such a request other than to say that it is a reference to an entity
+                $context['IsReference'] = $true
+                $context['IsEntity'] = $true
+                break
+            } elseif ($segment -eq '$entity' ) {
+                $context['IsEntity'] = $true
+                # anything after this is a property path
+                continue
+            } elseif ( $segment -eq '$delta' ) {
+                # This is always the last element
+                $context['IsDelta'] = $true
+                break
+            } elseif ( $segment -eq '$link' ) {
+                $context['IsNewLink'] = $true
+            } elseif ( $segment -eq '$deletedEntity' ) {
+                $context['IsDeletedEntity'] = $true
+            } elseif ( $segment -eq '$deletedLink' ) {
+                $context['IsDeletedLink'] = $true
+            } else {
+                $isLastSegment = $fragmentSegmentIndex -eq ( $fragmentSegments.length - 1 )
+
+                if ( ! $isLastSegment ) {
+                    $isLastSegment = $fragmentSegments[$fragmentSegmentIndex + 1][0] -eq '$'
+                }
+
+                $parsedSegment = __ParseSegment $segment $isLastSegment
+
+                if ( $parsedSegment ) {
+                    if ( $parsedSegment.IsRefCollection ) {
+                        $context['IsReference'] = $true
+                    } elseif ( ! $context['IsEntity'] ) {
+                        # Anything following entity is a property-path, type-name, or select-list
+                        if ( $parsedSegment.name ) {
+                            $segments += $parsedSegment.Name
+                        }
+
+                        if ( $parsedSegment.Id ) {
+                            $segments += $parsedSegment.Id
+                        }
+                    } elseif ( ! $parsedSegment.TypeCast ) {
+                        # If it's not a type name, it's either an explicit select-list or a property-path,
+                        # which is the equivalent of a select-list
+                        $context['SelectedProperties'] = $parsedSegment.Name
+                    }
+
+                    if ( $parsedSegment.TypeCast ) {
+                        $context['TypeCast'] = $parsedSegment.TypeCast
+                        if ( $parsedSegment.IsTypecastOnlySegment ) {
+                            $hasTypecastOnlySegment = $true
+                        }
+                    }
+
+                    if ( $parsedSegment.SelectedProperties ) {
+                        $context['SelectedProperties'] = $parsedSegment.SelectedProperties
+                    }
+
+                    if ( $parsedSegment.ExpandedProperties ) {
+                        $context['ExpandedProperties'] = $parsedSegment.ExpandedProperties
+                    }
+                }
+            }
+        }
+
+        $graphUri = if ( $segments -and ( $segments[0] -ne 'Collection' ) ) {
+            $context['Root'] = $segments[0]
+            $segments -join '/'
+        }
+
+        if ( $graphUri ) {
+            $context['TypelessGraphUri'] = "/$graphUri"
+        }
+
+        if ( $context['Root'] -and $context['Root'] -ne 'Collection' ) {
+            $context['GraphUri'] = if ( $hasTypeCastOnlySegment ) {
+                $context['TypelessGraphuri'], $context['TypeCast'] -join '/'
+            } else {
+                "/$graphUri"
+            }
+        }
+    }
+
+    function __ParseSegment($segment, $isLastNonSystemSegment) {
+        $name = $null
+        $id = $null
+        $expandedProperties = $null
+        $selectedProperties = $null
+        $typeCast = $null
+        $typeCastOnly = $false
+        $isRefCollection = $false
+
+        # Look for a parameterized segment
+        $parsedParameters = if ( $segment -match '(?<name>[^\(\)]+)(?<parameters>\(.+\))' ) {
+            __ParseParameters $matches.parameters
+        }
+
+        if ( $parsedParameters ) {
+            $selectList = $parsedParameters.SelectList
+            $parameterString = $parsedParameters.Parameters
+
+            # This may be a type cast -- if so, it has a qualified name,
+            # which always has a '.', so look for that to identify the cast
+            if ( $matches.name.Contains('.') ) {
+                $parsedSelect = __ParseSelectList $parameterString
+                $selectedProperties = $parsedSelect.SelectedProperties
+                $expandedProperties = $parsedSelect.ExpandedProperties
+                $typeCastOnly = $true
+                $typeCast = $matches.name
+            } else {
+                $name = $matches.name
+
+                if ( $parameterString.Contains('.') ) {
+                    $parsedSelect = __ParseSelectList $selectList
+                    $selectedProperties = $parsedSelect.SelectedProperties
+                    $expandedProperties = $parsedSelect.ExpandedProperties
+                    $typeCast = $parameterString
+                } else {
+                    # If this is the last segment not supplied by the service (as opposed to the caller), it must be a select / expand
+                    if ( $isLastNonSystemSegment ) {
+                        $parsedSelect = __ParseSelectList $parameterString
+                        if ( $parsedSelect ) {
+                            $expandedProperties = $parsedSelect.ExpandedProperties
+
+                            if ( $parsedSelect.SelectedProperties -contains '$ref' ) {
+                                $selectedProperties = $parsedSelect.SelectedProperties | where { $_ -ne '$ref' }
+                                $isRefCollection = $true
+                            } else {
+                                $selectedProperties = $parsedSelect.SelectedProperties
+                            }
+                        }
+                    } else {
+                        # It's not the last segment, so it must be an id
+                        $id = $parameterString
+                    }
+                }
+            }
+        } else {
+            # There are no parameters, the name is just the segment or a type cast
+            if ( $segment.Contains('.') ) {
+                $typeCast = $segment
+                $typeCastOnly = $true
+            } else {
+                $name = $segment
+            }
+        }
+
+        if ( $name -or $typeCastOnly ) {
+            @{
+                Name = $name
+                Id = $id
+                ExpandedProperties = $expandedProperties
+                SelectedProperties = $selectedProperties
+                TypeCast = $typeCast
+                IsTypeCastOnlySegment = $typeCastOnly
+                IsRefCollection = $isRefCollection
+            }
+        }
+    }
+
+    function __ParseParameters($parameterString) {
+        $parameters = $null
+        $selectList = $null
+
+        $parameters = if ( $parameterString -match '\((?<parameters>.+)\)\((?<selectlist>.+)\)$' ) {
+            $selectList = $matches.selectlist
+            $matches.parameters
+        } elseif ( $parameterString -match '\((?<parameters>.+)\)' ) {
+            $matches.parameters
+        }
+
+        if ( $parameters ) {
+            [PSCustomObject] @{
+                Parameters = $parameters
+                SelectList = $selectList
+            }
+        }
+    }
+
+    function __NormalizeSegments([string[]] $segments) {
+        $incompleteSegment = ''
+        $normalizedSegments = @()
+
+        $segmentIndex = 0
+        foreach ( $segment in $segments ) {
+            $currentSegment = if ( $incompleteSegment ) {
+                $incompleteSegment += "/$segment"
+                $incompleteSegment
+            } else {
+                $segment
+            }
+
+            if ( $currentSegment.Contains('(') -or $currentSegment.Contains(')') ) {
+                $left = 0
+                $right = 0
+                $currentIndex = 0
+                $balance = 0
+
+                $currentSegment.GetEnumerator() | foreach {
+                    if ( $_ -eq '(' ) {
+                        $left += 1
+                        $balance += 1
+                    } elseif ( $_ -eq ')' ) {
+                        $right += 1
+                        $balance -= 1
+                    }
+
+                    if ( $balance -lt 0 ) {
+                        throw "A segment '$currentSegment' contained too many closing ')' characters"
+                    }
+
+                    $currentIndex++
+                }
+
+                if ( $balance -eq 0 ) {
+                     $incompleteSegment = ''
+                } else {
+                    $incompleteSegment = $currentSegment
+                }
+            }
+
+            if ( ! $incompleteSegment ) {
+                $normalizedSegments += $currentSegment
+            }
+        }
+
+        if ( $incompleteSegment ) {
+            throw "The segment '$incompleteSegment' is missing one or more closing ')' characters"
+        }
+
+        , $normalizedSegments
+    }
+
+    function __ParseSelectList($selectString) {
+        # Note that this only parses the first level -- nested elements are ignored,
+        # so this is incomplete.
+        # TODO: Add support for multiple nesting levels
+
+        # The approach here is to replace parenthesized expressions, including the
+        # ',' characters, with a '#' that should not otherwise be in the string.
+        # After that's done, the idea is that the only ',' chars that will be
+        # left are those on the first level, and we can then assume those are appended
+        # to expanded fields.
+        $replacedEmptyParens = $selectString -replace "(\(\))+", "#"
+        $replacedParens = $replacedEmptyParens -replace "(\(.+,.+\))+", "#"
+
+        $properties = $replacedParens -split ','
+
+        $selectedProperties = @()
+        $expandedProperties = @()
+
+        foreach ( $property in $properties ) {
+            if ( $property.Contains('#') ) {
+                $normalizedProperty = $property -split '/' | select -first 1
+                $expandedProperty = $normalizedProperty.TrimEnd('#').TrimEnd('+')
+                $expandedProperties += $expandedProperty
+            } else {
+                $selectedProperties += $property
+            }
+
+            $normalizedProperty = $property -split '/' | select -first 1
+        }
+
+        [PSCustomObject] @{
+            SelectedProperties = $selectedProperties
+            ExpandedProperties = $expandedProperties
+        }
+    }
+
+    function __NormalizePath($path) {
+    }
+}

--- a/src/common/ResponseContext.tests.ps1
+++ b/src/common/ResponseContext.tests.ps1
@@ -1,0 +1,909 @@
+# Copyright 2020, Adam Edwards
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. $psscriptroot/ResponseContext.ps1
+
+Describe 'ResponseContext class' {
+    Context "When parsing a response context URL" {
+        It 'Should throw if the ResponseContext instance is initialized with both requestUrl and contextUrl set to $null' {
+            { $responseContext = new-so ResponseContext $null $null } | Should Throw 'must not be $null'
+        }
+
+        It 'Should be able to parse a users entity set graph URI of the form "https://graph.microsoft.com/v1.0/$metadata#users/$entity" and request url is null' {
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#users/$entity'
+
+            $responseContext = new-so ResponseContext $null $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/users'
+            $responseContext.TypelessGraphUri | Should Be '/users'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/users'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $null
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $true
+            $responseContext.Root | Should Be 'users'
+        }
+
+        It "Should be able to parse a users entity set graph URI when only the request url is supplied" {
+            $requestUri = 'https://graph.microsoft.com/v1.0/users'
+
+            $responseContext = new-so ResponseContext $requestUri $null |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/users'
+            $responseContext.TypelessGraphUri | Should Be '/users'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/users'
+            $responseContext.ContextUrl | Should Be $null
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.Root | Should Be 'users'
+        }
+
+        It 'Should be able to parse a users entity set graph URI of the form "https://graph.microsoft.com/v1.0/$metadata#users/$entity" and request url is "https://graph.microsoft.com/v1.0/users/userid"' {
+            $requestUri = 'https://graph.microsoft.com/v1.0/users/userid'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#users/$entity'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/users'
+            $responseContext.TypelessGraphUri | Should Be '/users'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/users'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $true
+            $responseContext.Root | Should Be 'users'
+        }
+    }
+
+    Context 'When ResponseContext processes the URLs from the OData 4.01 specification examples for Context URL at https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_ContextURL' {
+
+        It 'Should correctly parse example 10.1 Service Document - {context-url} - with $metadata segment' {
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata'
+
+            $responseContext = new-so ResponseContext $null $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be $null
+            $responseContext.TypelessGraphUri | Should Be $null
+            $responseContext.AbsoluteGraphUri | Should Be $null
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $null
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.Root | Should Be $null
+        }
+
+        It 'Should correctly parse example 10.1 Service Document - {context-url} - without $metadata segment' {
+            $contextUri = 'https://graph.microsoft.com/v1.0'
+
+            $responseContext = new-so ResponseContext $null $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be $null
+            $responseContext.TypelessGraphUri | Should Be $null
+            $responseContext.AbsoluteGraphUri | Should Be $null
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $null
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.Root | Should Be $null
+        }
+
+        It "Should correctly parse example 10.2 Collection of Entities - {context-url}#{entity=set}" {
+            $requestUri = 'https://graph.microsoft.com/v1.0/users'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#users'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/users'
+            $responseContext.TypelessGraphUri | Should Be '/users'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/users'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.Root | Should Be 'users'
+        }
+
+        It "Should correctly parse example 10.2 Collection of Entities - {context-url}#Collection({type-name})" {
+            $requestUri = 'https://graph.microsoft.com/v1.0/users'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#users(microsoft.graph.user)'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/users'
+            $responseContext.TypelessGraphUri | Should Be '/users'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/users'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be 'microsoft.graph.user'
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.Root | Should Be 'users'
+        }
+
+        It 'Should correctly parse 10.3 Entity - {context-url}#{entity-set}/$entity' {
+            $requestUri = 'https://graph.microsoft.com/v1.0/users/userid'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#users/$entity'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/users'
+            $responseContext.TypelessGraphUri | Should Be '/users'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/users'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $true
+            $responseContext.Root | Should Be 'users'
+        }
+
+        It "Should correctly parse 10.3 Entity - {context-url}#{type-name} -- can be used in cases when entity is returned from an action or function" {
+            $requestUri = 'https://graph.microsoft.com/v1.0/users/someaction'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#graph.user'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be $null
+            $responseContext.TypelessGraphUri | Should Be $null
+            $responseContext.AbsoluteGraphUri | Should Be $null
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be 'graph.user'
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.Root | Should Be $null
+        }
+
+        It "Should correctly parse 10.4 Singleton - {context-url}#{singleton}" {
+            $requestUri = 'https://graph.microsoft.com/v1.0/me'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#me'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/me'
+            $responseContext.TypelessGraphUri | Should Be '/me'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/me'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.Root | Should Be 'me'
+        }
+
+        It 'Should correctly parse 10.6 Derived Entity - {context-url}#{entity-set}{/type-name}/$entity' {
+            $requestUri = 'https://graph.microsoft.com/v1.0/users/userid/Mail.User'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#users/Mail.User/$entity'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+            $responseContext.GraphUri | Should Be '/users/Mail.User'
+            $responseContext.TypelessGraphUri | Should Be '/users'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/users/Mail.user'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be 'Mail.User'
+            $responseContext.IsEntity | Should Be $true
+            $responseContext.Root | Should Be 'users'
+        }
+
+        It 'Should correctly parse 10.7 Collection of Projected Entities - {context-url}#{entity-set}{/type-name}{select-list}' {
+            $requestUri = 'https://graph.microsoft.com/v1.0/users?$select=displayName,mail'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#users(displayName,mail)'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+            $responseContext.GraphUri | Should Be '/users'
+            $responseContext.TypelessGraphUri | Should Be '/users'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/users'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.SelectedProperties | sort | Should Be ('displayName', 'mail' | sort)
+            $responseContext.Root | Should Be 'users'
+        }
+
+        It 'Should correctly parse 10.7 Collection of Projected Entities - {context-url}#Collection({type-name}){select-list}' {
+            $requestUri = 'https://graph.microsoft.com/v1.0/me/memberOf/microsoft.graph.group?$select=displayName,id'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#groups(microsoft.graph.group)(displayName,id)'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+            $responseContext.GraphUri | Should Be '/groups'
+            $responseContext.TypelessGraphUri | Should Be '/groups'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/groups'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be 'microsoft.graph.group'
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.SelectedProperties | sort | Should Be ('displayName', 'id' | sort)
+            $responseContext.Root | Should Be 'groups'
+        }
+
+        It 'Should correctly parse 10.8 Projected Entity - {context-url}#{entity-set}{select-list}/$entity' {
+            $requestUri = 'https://graph.microsoft.com/v1.0/users/userid/?$select=displayName,mail'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#users(displayName,mail)/$entity'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+            $responseContext.GraphUri | Should Be '/users'
+            $responseContext.TypelessGraphUri | Should Be '/users'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/users'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $true
+            $responseContext.SelectedProperties | sort | Should Be ('displayName', 'mail' | sort)
+            $responseContext.Root | Should Be 'users'
+        }
+
+        It 'Should correctly parse 10.8 Projected Entity - {context-url}#{entity-set}{/type-name}{select-list}/$entity' {
+            $requestUri = 'https://graph.microsoft.com/v1.0/users/userid/microsoft.graph.user?$select=displayName,mail'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#users/microsoft.graph.user(displayName,mail)/$entity'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/users/microsoft.graph.user'
+            $responseContext.TypelessGraphUri | Should Be '/users'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/users/microsoft.graph.user'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be 'microsoft.graph.user'
+            $responseContext.IsEntity | Should Be $true
+            $responseContext.SelectedProperties | sort | Should Be ('displayName', 'mail' | sort)
+            $responseContext.Root | Should Be 'users'
+        }
+
+        It 'Should correctly parse 10.8 Projected Entity - {context-url}#{singleton}{select-list}' {
+            $requestUri = 'https://graph.microsoft.com/v1.0/me?$select=displayName,mail'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#me(displayName,mail)'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/me'
+            $responseContext.TypelessGraphUri | Should Be '/me'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/me'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.SelectedProperties | sort | Should Be ('displayName', 'mail' | sort)
+            $responseContext.Root | Should Be 'me'
+        }
+
+        It 'Should correctly parse 10.8 Projected Entity - {context-url}#{type-name}{select-list}' {
+            $requestUri = 'https://graph.microsoft.com/v1.0/groups/groupid/members?$select=displayName,mail'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#microsoft.graph.directoryObject(displayName,mail)'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be $null
+            $responseContext.TypelessGraphUri | Should Be $null
+            $responseContext.AbsoluteGraphUri | Should Be $null
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be 'microsoft.graph.directoryObject'
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.SelectedProperties | sort | Should Be ('displayName', 'mail' | sort)
+            $responseContext.Root | Should Be $null
+        }
+
+        It "Should correctly parse 10.9 Projected Entity - {context-url}#{entity-set}{select-list} when a property is expanded" {
+            $requestUri = 'https://host/service/Customers?$select=Name,Company&$expand=Address,Office'
+            $contextUri = 'https://host/service/$metadata#Customers(Name,Address(),Office(),Company)'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/Customers'
+            $responseContext.TypelessGraphUri | Should Be '/Customers'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://host/service/Customers'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.SelectedProperties | sort | Should Be ('Name', 'Company' | sort)
+            $responseContext.ExpandedProperties | sort | Should Be ('Address', 'Office' | sort)
+            $responseContext.Root | Should Be 'Customers'
+        }
+
+        It "Should correctly parse 10.9 Projected Entity - {context-url}#{entity-set}{/type-name}{select-list} when a property is expanded" {
+            $requestUri = 'https://host/service/Customers/Customer.Wholesale?$select=Name,Company&$expand=Address,Office'
+            $contextUri = 'https://host/service/$metadata#Customers/Customer.Wholesale(Name,Address(),Office(),Company)'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/Customers/Customer.Wholesale'
+            $responseContext.TypelessGraphUri | Should Be '/Customers'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://host/service/Customers/Customer.Wholesale'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be 'Customer.Wholesale'
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.SelectedProperties | sort | Should Be ('Name', 'Company' | sort)
+            $responseContext.ExpandedProperties | sort | Should Be ('Address', 'Office' | sort)
+            $responseContext.Root | Should Be 'Customers'
+        }
+
+        It "Should correctly parse 10.9 Projected Entity - {context-url}#{entity-set}{select-list} when a navigation property's property is expanded" {
+            $requestUri = 'https://host/service/Customers?$select=Name&$expand=Address/Country'
+            $contextUri = 'https://host/service/$metadata#Customers(Name,Address/Country())'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/Customers'
+            $responseContext.TypelessGraphUri | Should Be '/Customers'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://host/service/Customers'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.SelectedProperties | Should Be @('Name')
+            $responseContext.ExpandedProperties | Should Be @('Address')
+            $responseContext.Root | Should Be 'Customers'
+        }
+
+        It "Should correctly parse 10.9 Projected Entity - {context-url}#{entity-set}{select-list} should throw when a segment does not contain equal number of open and closed parens" {
+            { new-so ResponseContext $null 'https://host/service/$metadata#Customers(Name,Address/Country(())' |=> ToPublicContext | out-null } | Should Throw "is missing one or more closing"
+            { new-so ResponseContext $null 'https://host/service/$metadata#Customers(Name,Address/Country()))' |=> ToPublicContext | out-null } | Should Throw "contained too many closing"
+            { new-so ResponseContext $null 'https://host/service/$metadata#Customers(Name,Address/Country))' |=> ToPublicContext | out-null } | Should Throw "contained too many closing"
+            { new-so ResponseContext $null 'https://host/service/$metadata#Customers(Name,Address/Country()' |=> ToPublicContext | out-null } | Should Throw "is missing one or more closing"
+            { new-so ResponseContext $null 'https://host/service/$metadata#Customers(Name,Address(())' |=> ToPublicContext | out-null } | Should Throw "is missing one or more closing"
+            { new-so ResponseContext $null 'https://host/service/$metadata#Customers(Name,Address()))' |=> ToPublicContext | out-null } | Should Throw "contained too many closing"
+            { new-so ResponseContext $null 'https://host/service/$metadata#Customers(Name,Address))' |=> ToPublicContext | out-null } | Should Throw "contained too many closing"
+            { new-so ResponseContext $null 'https://host/service/$metadata#Customers(Name,Address()' |=> ToPublicContext | out-null } | Should Throw "is missing one or more closing"
+        }
+
+        It "Should correctly parse 10.9 Projected Entity - {context-url}#{entity-set}{select-list} should throw when a segment contains equal number of open and closed parens but they are not balanced" {
+            { new-so ResponseContext $null 'https://host/service/$metadata#Customers(Name,Address/Country))(()' |=> ToPublicContext | out-null } | Should Throw "contained too many closing"
+        }
+
+        It 'Should correctly parse 10.10 Expanded Entity - {context-url}#{entity-set}{/type-name}{select-list}/$entity and {/type-name} segment is not specified' {
+            $requestUri = 'https://host/service/Employees(1)?$expand=DirectReports($select=FirstName,LastName)'
+            $contextUri = 'https://host/service/$metadata#Employees(DirectReports+(FirstName,LastName))/$entity'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/Employees'
+            $responseContext.TypelessGraphUri | Should Be '/Employees'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://host/service/Employees'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $true
+            $responseContext.SelectedProperties | sort | Should Be $null
+            $responseContext.ExpandedProperties | sort | Should Be ('DirectReports' | sort)
+            $responseContext.Root | Should Be 'Employees'
+        }
+
+        It 'Should correctly parse 10.10 Expanded Entity - {context-url}#{entity-set}{/type-name}{select-list}/$entity and the type-name is specified' {
+            $requestUri = 'https://host/service/Employees(1)/Sales.Manager?$expand=DirectReports($select=FirstName,LastName)'
+            $contextUri = 'https://host/service/$metadata#Employees/Sales.Manager(DirectReports+(FirstName,LastName))/$entity'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/Employees/Sales.Manager'
+            $responseContext.TypelessGraphUri | Should Be '/Employees'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://host/service/Employees/Sales.Manager'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be 'Sales.Manager'
+            $responseContext.IsEntity | Should Be $true
+            $responseContext.SelectedProperties | sort | Should Be $null
+            $responseContext.ExpandedProperties | sort | Should Be ('DirectReports' | sort)
+            $responseContext.Root | Should Be 'Employees'
+        }
+
+        It 'Should correctly parse 10.10 Expanded Entity - {context-url}#{singleton}{select-list}' {
+            $requestUri = 'https://host/service/me$expand=DirectReports($select=FirstName,LastName)'
+            $contextUri = 'https://host/service/$metadata#me(DirectReports+(FirstName,LastName))'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/me'
+            $responseContext.TypelessGraphUri | Should Be '/me'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://host/service/me'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.SelectedProperties | sort | Should Be $null
+            $responseContext.ExpandedProperties | sort | Should Be ('DirectReports' | sort)
+            $responseContext.Root | Should Be 'me'
+        }
+
+        It 'Should correctly parse 10.10 Expanded Entity - {context-url}#{type-name}{select-list}' {
+            $requestUri = 'https://host/service/Employees/Managers?$expand=DirectReports($select=FirstName,LastName)'
+            $contextUri = 'https://host/service/$metadata#Sales.Manager(DirectReports+(FirstName,LastName))'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be $null
+            $responseContext.TypelessGraphUri | Should Be $null
+            $responseContext.AbsoluteGraphUri | Should Be $null
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be 'Sales.Manager'
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.SelectedProperties | sort | Should Be $null
+            $responseContext.ExpandedProperties | sort | Should Be ('DirectReports' | sort)
+            $responseContext.Root | Should Be $null
+        }
+
+        It 'Should correctly parse a context URI for 10.11 collection of entity references of the form {context-url}#Collection($ref) -- this means the context URL does not contain the type of the referenced entities' {
+            $requestUri = 'https://host/service/Employees(1)/Orders/$ref'
+            $contextUri = 'https://host/service/$metadata#Collection($ref)'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be $null
+            $responseContext.TypelessGraphUri | Should Be $null
+            $responseContext.AbsoluteGraphUri | Should Be $null
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.SelectedProperties | Should Be $null
+            $responseContext.ExpandedProperties | Should Be $null
+            $responseContext.Root | Should Be $null
+            $responseContext.IsReference | Should Be $true
+        }
+
+        It 'Should correctly parse a context URI for 10.12 a single entity reference of the form {context-url}#$ref -- this means the context URL does not contain the type of the referenced entitiy' {
+            $requestUri = 'https://host/service/Orders(10643)/Customer/$ref'
+            $contextUri = 'https://host/service/$metadata#$ref'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be $null
+            $responseContext.TypelessGraphUri | Should Be $null
+            $responseContext.AbsoluteGraphUri | Should Be $null
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $true
+            $responseContext.SelectedProperties | Should Be $null
+            $responseContext.ExpandedProperties | Should Be $null
+            $responseContext.Root | Should Be $null
+            $responseContext.IsReference | Should Be $true
+        }
+
+        It 'Should correctly parse 10.13 Property Value: {context-url}#{entity}/{property-path}{select-list}' {
+            $requestUri = 'https://host/service/Employees(1)/Address?$select=City,State'
+            $contextUri = 'https://host/service/$metadata#Employees/Address(City,State)'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/Employees/Address'
+            $responseContext.TypelessGraphUri | Should Be '/Employees/Address'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://host/service/Employees/Address'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.SelectedProperties | sort | Should Be ('City', 'State' | sort)
+            $responseContext.ExpandedProperties | sort | Should Be $null
+            $responseContext.Root | Should Be 'Employees'
+        }
+
+        It -Skip 'Should correctly parse 10.14 Collection of Complex or Primitive Types: {context-url}#Collection({type-name}){select-list} -- should be covered by other cases so not explicitly tested' {
+        }
+
+        It -Skip 'Should correctly parse 10.16 Operation Result: {context-url}#{entity-set}{/type-name}{select-list} {context-url}#{entity-set}{/type-name}{select-list}/$entity {context-url}#{entity}/{property-path}{select-list} {context-url}#Collection({type-name}){select-list} {context-url}#{type-name}{select-list} -- should be covered by other cases so not explicitly tested' {
+        }
+
+        It 'Should correctly parse 10.17 Delta Payload Response: {context-url}#{entity-set}{/type-name}{select-list}/$delta' {
+            $requestUri = 'https://host/service/Employees(1)/Sales.Manager?$select=FirstName,LastName/$delta'
+            $contextUri = 'https://host/service/$metadata#Employees/Sales.Manager(FirstName,LastName)/$delta'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/Employees/Sales.Manager'
+            $responseContext.TypelessGraphUri | Should Be '/Employees'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://host/service/Employees/Sales.Manager'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be 'Sales.Manager'
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.SelectedProperties | sort | Should Be ( 'FirstName', 'LastName' | sort )
+            $responseContext.ExpandedProperties | Should Be $null
+            $responseContext.Root | Should Be 'Employees'
+            $responseContext.IsDelta | Should Be $true
+        }
+
+        It 'Should correctly parse 10.17 Delta Payload Response: The context URL of an update request body for a collection of entities is simply the fragment #$delta' {
+            $requestUri = 'https://graph.microsoft.com/v1.0/groups/mygroup/members'
+            $contextUri = 'https://host/service/$metadata#$delta'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be $null
+            $responseContext.TypelessGraphUri | Should Be $null
+            $responseContext.AbsoluteGraphUri | Should Be $null
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.SelectedProperties | Should Be $null
+            $responseContext.ExpandedProperties | Should Be $null
+            $responseContext.Root | Should Be $null
+            $responseContext.IsReference | Should Be $false
+            $responseContext.IsDelta | Should Be $true
+        }
+
+        It 'Should correctly parse 10.18 Item in a Delta Payload Response: {context-url}#{entity-set}/$deletedEntity' {
+            $requestUri = 'https://graph.microsoft.com/v1.0/users/?$deltaToken=xxxxx'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#users/$deletedEntity'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/users'
+            $responseContext.TypelessGraphUri | Should Be '/users'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/users'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsDeletedEntity | Should Be $true
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.Root | Should Be 'users'
+        }
+
+        It 'Should correctly parse 10.18 Item in a Delta Payload Response: {context-url}#{entity-set}/$deletedLink' {
+            $requestUri = 'https://graph.microsoft.com/v1.0/groups/?$deltaToken=xxxxx'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#groups/$deletedLink'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/groups'
+            $responseContext.TypelessGraphUri | Should Be '/groups'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/groups'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsDeletedLink | Should Be $true
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.Root | Should Be 'groups'
+        }
+
+        It 'Should correctly parse 10.18 Item in a Delta Payload Response: {context-url}#{entity-set}/$link' {
+            $requestUri = 'https://graph.microsoft.com/v1.0/groups/?$deltaToken=xxxxx'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#groups/$link'
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/groups'
+            $responseContext.TypelessGraphUri | Should Be '/groups'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/groups'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsNewLink | Should Be $true
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.Root | Should Be 'groups'
+        }
+    }
+}
+
+<#
+https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_ContextURL
+
+
+
+10.1 Service Document
+{context-url}
+
+https://host/service/
+https://host/service/$metadata
+
+10.2 Collection of Entities
+{context-url}#{entity-set}
+{context-url}#Collection({type-name})
+
+https://host/service/Customers
+https://host/service/$metadata#Customers
+
+https://host/service/Orders(4711)/Items
+https://host/service/$metadata#Orders(4711)/Items
+
+10.3 Entity
+{context-url}#{entity-set}/$entity
+{context-url}#{type-name}
+
+https://host/service/Customers(1)
+https://host/service/$metadata#Customers/$entity
+
+Example 14: resource URL and corresponding context URL for contained entity
+https://host/service/Orders(4711)/Items(1)
+https://host/service/$metadata#Orders(4711)/Items/$entity
+
+10.4 Singleton
+Context URL template:
+
+{context-url}#{singleton}
+
+# If a response or response part is a singleton, its name is the context URL fragment.
+
+Example 15: resource URL and corresponding context URL
+
+https://host/service/MainSupplier
+https://host/service/$metadata#MainSupplier
+
+10.5 Collection of Derived Entities
+{context-url}#{entity-set}{/type-name}
+
+If an entity set consists exclusively of derived entities, a type-cast segment is added to the context URL.
+
+Example 16: resource URL and corresponding context URL
+
+https://host/service/Customers/Model.VipCustomer
+
+https://host/service/$metadata#Customers/Model.VipCustomer
+
+10.6 Derived Entity
+Context URL template:
+
+{context-url}#{entity-set}{/type-name}/$entity
+
+If a response or response part is a single entity of a type derived from the declared type of an entity set, a type-cast segment is appended to the entity set name.
+
+Example 17: resource URL and corresponding context URL
+
+https://host/service/Customers(2)/Model.VipCustomer
+
+https://host/service/$metadata#Customers/Model.VipCustomer/$entity
+
+10.7 Collection of Projected Entities
+Context URL templates:
+
+{context-url}#{entity-set}{/type-name}{select-list}
+
+{context-url}#Collection({type-name}){select-list}
+
+If a result contains only a subset of properties, the parenthesized comma-separated list of the selected defined or dynamic properties, instance annotations, navigation properties, functions, and actions is appended to the context URL representing the collection of entities.
+
+Regardless of how contained structural properties are represented in the request URL (as paths or as select options) they are represented in the context URL using path syntax, as defined in OData 4.0.
+
+The shortcut * represents the list of all structural properties. Properties defined on types derived from the declared type of the entity set (or type specified in the type-cast segment if specified) are prefixed with the qualified name of the derived type as defined in [OData-ABNF].
+
+The list also contains explicitly selected or expanded instance annotations. It is possible to select or expand only instance annotations, in which case only those selected or expanded annotations appear in the result. Note that annotations specified only in the include-annotations preference do not appear in the context URL and do not affect the selected/expanded properties.
+
+Operations in the context URL are represented using the namespace- or alias-qualified name. Function names suffixed with parentheses represent a specific overload, while function names without parentheses represent all overloads of the function.
+
+OData 4.01 responses MAY use the shortcut pattern {namespace}.* to represent the list of all bound actions or functions available for entities in the collection, see system query option $select.
+
+Example 18: resource URL and corresponding context URL
+
+https://host/service/Customers?$select=Address,Orders
+
+https://host/service/$metadata#Customers(Address,Orders)
+
+10.8 Projected Entity
+Context URL templates:
+
+{context-url}#{entity-set}{/type-name}{select-list}/$entity
+
+{context-url}#{singleton}{select-list}
+
+{context-url}#{type-name}{select-list}
+
+If a single entity contains a subset of properties, the parenthesized comma-separated list of the selected defined or dynamic properties, instance annotations, navigation properties, functions, and actions is appended to the {entity-set} after an optional type-cast segment and prior to appending /$entity. If the response is not a subset of a single entity set, the {select-list} is instead appended to the {type-name} of the returned entity.
+
+Regardless of how contained structural properties are represented in the request URL (as paths or as select options) they are represented in the context URL using path syntax, as defined in OData 4.0.
+
+The shortcut * represents the list of all structural properties. Properties defined on types derived from the type of the entity set (or type specified in the type-cast segment if specified) are prefixed with the qualified name of the derived type as defined in [OData-ABNF]. Note that expanded properties are automatically included in the response.
+
+The list also contains explicitly selected or expanded instance annotations. It is possible to select or expand only instance annotations, in which case only those selected or expanded annotations appear in the result. Note that annotations specified only in the include-annotations preference do not appear in the context URL and do not affect the selected/expanded properties.
+
+Operations in the context URL are represented using the namespace- or alias-qualified name. Function names suffixed with parentheses represent a specific overload, while function names without parentheses represent all overloads of the function.
+
+OData 4.01 responses MAY use the shortcut pattern {namespace}.* to represent the list of all bound actions or functions available for the returned entity, see system query option $select.
+
+Example 19: resource URL and corresponding context URL
+
+https://host/service/Customers(1)?$select=Name,Rating
+
+https://host/service/$metadata#Customers(Name,Rating)/$entity
+
+10.9 Collection of Expanded Entities
+Context URL template:
+
+{context-url}#{entity-set}{/type-name}{select-list}
+
+{context-url}#Collection({type-name}){select-list}
+
+For a 4.01 response, if a navigation property is explicitly expanded, then in addition to any non-suffixed names of any selected properties, navigation properties, functions or actions, the comma-separated list of properties MUST include the name of the expanded property, suffixed with the parenthesized comma-separated list of any properties of the expanded navigation property that are selected or expanded. If the expanded navigation property does not contain a nested $select or $expand, then the expanded property is suffixed with empty parentheses. If the expansion is recursive for nested children, a plus sign (+) is infixed between the navigation property name and the opening parenthesis.
+
+For a 4.0 response, the expanded navigation property suffixed with parentheses is omitted from the select-list if it does not contain a nested $select or $expand, but MUST still be present, without a suffix, if it is explicitly selected.
+0
+If the context URL includes only expanded navigation properties (i.e., only navigation properties suffixed with parentheses), then all structural properties are implicitly selected (same as if there were no properties listed in the select-list).
+
+Navigation properties with expanded references are not represented in the context URL.
+
+Example 20: resource URL and corresponding context URL - select and expand
+
+https://host/service/Customers?$select=Name&$expand=Address/Country
+
+https://host/service/$metadata#Customers(Name,Address/Country())
+
+Example 21: resource URL and corresponding context URL – expand $ref
+
+https://host/service/Customers?$expand=Orders/$ref
+
+https://host/service/$metadata#Customers
+
+Example 22: resource URL and corresponding context URL – expand with $levels
+
+https://host/service/Employees/Sales.Manager?$select=DirectReports
+                &$expand=DirectReports($select=FirstName,LastName;$levels=4)
+
+https://host/service/$metadata
+                #Employees/Sales.Manager(DirectReports,
+                                         DirectReports+(FirstName,LastName))
+
+10.10 Expanded Entity
+Context URL template:
+
+{context-url}#{entity-set}{/type-name}{select-list}/$entity
+
+{context-url}#{singleton}{select-list}
+
+{context-url}#{type-name}{select-list}
+
+For a 4.01 response, if a navigation property is explicitly expanded, then in addition to the non-suffixed names of any selected properties, navigation properties, functions or actions, the comma-separated list of properties MUST include the name of the expanded property, suffixed with the parenthesized comma-separated list of any properties of the expanded navigation property that are selected or expanded. If the expanded navigation property does not contain a nested $select or $expand, then the expanded property is suffixed with empty parentheses. If the expansion is recursive for nested children, a plus sign (+) is infixed between the navigation property name and the opening parenthesis.
+
+For a 4.0 response, the expanded navigation property suffixed with parentheses is omitted from the select-list if it does not contain a nested $select or $expand, but MUST still be present, without a suffix, if it is explicitly selected.
+
+If the context URL includes only expanded navigation properties (i.e., only navigation properties suffixed with parentheses), then all structural properties are implicitly selected (same as if there were no properties listed in the select-list).
+
+Navigation properties with expanded references are not represented in the context URL.
+
+Example 23: resource URL and corresponding context URL
+
+https://host/service/Employees(1)/Sales.Manager?
+                   $expand=DirectReports($select=FirstName,LastName;$levels=4)
+
+https://host/service/$metadata
+       #Employees/Sales.Manager(DirectReports+(FirstName,LastName))/$entity
+
+10.11 Collection of Entity References
+Context URL template:
+
+{context-url}#Collection($ref)
+
+If a response is a collection of entity references, the context URL does not contain the type of the referenced entities.
+
+Example 24: resource URL and corresponding context URL for a collection of entity references
+
+https://host/service/Customers('ALFKI')/Orders/$ref
+
+https://host/service/$metadata#Collection($ref)
+
+10.12 Entity Reference
+Context URL template:
+
+{context-url}#$ref
+
+If a response is a single entity reference, $ref is the context URL fragment.
+
+Example 25: resource URL and corresponding context URL for a single entity reference
+
+https://host/service/Orders(10643)/Customer/$ref
+
+https://host/service/$metadata#$ref
+
+10.13 Property Value
+Context URL templates:
+
+{context-url}#{entity}/{property-path}{select-list}
+
+{context-url}#{type-name}{select-list}
+
+If a response represents an individual property of an entity with a canonical URL, the context URL specifies the canonical URL of the entity and the path to the structural property of that entity. The path MUST include cast segments for properties defined on types derived from the expected type of the previous segment.
+
+If the property value does not contain explicitly or implicitly selected navigation properties or operations, OData 4.01 responses MAY use the less specific second template.
+
+Example 26: resource URL and corresponding context URL
+
+https://host/service/Customers(1)/Addresses
+
+https://host/service/$metadata#Customers(1)/Addresses
+
+10.14 Collection of Complex or Primitive Types
+Context URL template:
+
+{context-url}#Collection({type-name}){select-list}
+
+If a response is a collection of complex types or primitive types that do not represent an individual property of an entity with a canonical URL, the context URL specifies the fully qualified type of the collection.
+
+Example 27: resource URL and corresponding context URL
+
+https://host/service/TopFiveHobbies()
+
+https://host/service/$metadata#Collection(Edm.String)
+
+10.15 Complex or Primitive Type
+Context URL template:
+
+{context-url}#{type-name}{select-list}
+
+If a response is a complex type or primitive type that does not represent an individual property of an entity with a canonical URL, the context URL specifies the fully qualified type of the result.
+
+Example 28: resource URL and corresponding context URL
+
+https://host/service/MostPopularName()
+
+https://host/service/$metadata#Edm.String
+
+10.16 Operation Result
+Context URL templates:
+
+{context-url}#{entity-set}{/type-name}{select-list}
+
+{context-url}#{entity-set}{/type-name}{select-list}/$entity
+
+{context-url}#{entity}/{property-path}{select-list}
+
+{context-url}#Collection({type-name}){select-list}
+
+{context-url}#{type-name}{select-list}
+
+If the response from an action or function is a collection of entities or a single entity that is a member of an entity set, the context URL identifies the entity set. If the response from an action or function is a property of a single entity, the context URL identifies the entity and property. Otherwise, the context URL identifies the type returned by the operation. The context URL will correspond to one of the former examples.
+
+Example 29: resource URL and corresponding context URL
+
+https://host/service/TopFiveCustomers()
+
+https://host/service/$metadata#Customers
+
+10.17 Delta Payload Response
+Context URL template:
+
+{context-url}#{entity-set}{/type-name}{select-list}/$delta
+
+{context-url}#{entity}{select-list}/$delta
+
+{context-url}#{entity}/{property-path}{select-list}/$delta
+
+#$delta
+
+The context URL of a delta response is the context URL of the response to the defining query, followed by /$delta. This includes singletons, single-valued navigation properties, and collection-valued navigation properties.
+
+If the entities are contained, then {entity-set} is the top-level entity set followed by the path to the containment navigation property of the containing entity.
+
+Example 30: resource URL and corresponding context URL
+
+https://host/service/Customers?$deltatoken=1234
+
+https://host/service/$metadata#Customers/$delta
+
+The context URL of an update request body for a collection of entities is simply the fragment #$delta.
+
+10.18 Item in a Delta Payload Response
+Context URL templates:
+
+{context-url}#{entity-set}/$deletedEntity
+
+{context-url}#{entity-set}/$link
+
+{context-url}#{entity-set}/$deletedLink
+
+In addition to new or changed entities which have the canonical context URL for an entity, a delta response can contain deleted entities, new links, and deleted links. They are identified by the corresponding context URL fragment. {entity-set} corresponds to the set of the deleted entity, or source entity for an added or deleted link.
+
+10.19 $all Response
+Context URL template:
+
+{context-url}#Collection(Edm.EntityType)
+
+Responses to requests to the virtual collection $all (see [OData‑URL]) use the built-in abstract entity type. Each single entity in such a response has its individual context URL that identifies the entity set or singleton.
+
+10.20 $crossjoin Response
+Context URL template:
+
+{context-url}#Collection(Edm.ComplexType)
+
+Responses to requests to the virtual collections $crossjoin(...) (see [OData‑URL]) use the built-in abstract complex type. Single instances in these responses do not have a context URL.
+#>

--- a/src/common/ResponseContext.tests.ps1
+++ b/src/common/ResponseContext.tests.ps1
@@ -206,7 +206,7 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsEntity | Should Be $false
-            $responseContext.SelectedProperties | sort | Should Be ('displayName', 'mail' | sort)
+            $responseContext.SelectedProperties | sort-object | Should Be ('displayName', 'mail' | sort-object)
             $responseContext.Root | Should Be 'users'
         }
 
@@ -222,7 +222,7 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be 'microsoft.graph.group'
             $responseContext.IsEntity | Should Be $false
-            $responseContext.SelectedProperties | sort | Should Be ('displayName', 'id' | sort)
+            $responseContext.SelectedProperties | sort-object | Should Be ('displayName', 'id' | sort-object)
             $responseContext.Root | Should Be 'groups'
         }
 
@@ -238,7 +238,7 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsEntity | Should Be $true
-            $responseContext.SelectedProperties | sort | Should Be ('displayName', 'mail' | sort)
+            $responseContext.SelectedProperties | sort-object | Should Be ('displayName', 'mail' | sort-object)
             $responseContext.Root | Should Be 'users'
         }
 
@@ -255,7 +255,7 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be 'microsoft.graph.user'
             $responseContext.IsEntity | Should Be $true
-            $responseContext.SelectedProperties | sort | Should Be ('displayName', 'mail' | sort)
+            $responseContext.SelectedProperties | sort-object | Should Be ('displayName', 'mail' | sort-object)
             $responseContext.Root | Should Be 'users'
         }
 
@@ -272,7 +272,7 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsEntity | Should Be $false
-            $responseContext.SelectedProperties | sort | Should Be ('displayName', 'mail' | sort)
+            $responseContext.SelectedProperties | sort-object | Should Be ('displayName', 'mail' | sort-object)
             $responseContext.Root | Should Be 'me'
         }
 
@@ -289,7 +289,7 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be 'microsoft.graph.directoryObject'
             $responseContext.IsEntity | Should Be $false
-            $responseContext.SelectedProperties | sort | Should Be ('displayName', 'mail' | sort)
+            $responseContext.SelectedProperties | sort-object | Should Be ('displayName', 'mail' | sort-object)
             $responseContext.Root | Should Be $null
         }
 
@@ -306,8 +306,8 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsEntity | Should Be $false
-            $responseContext.SelectedProperties | sort | Should Be ('Name', 'Company' | sort)
-            $responseContext.ExpandedProperties | sort | Should Be ('Address', 'Office' | sort)
+            $responseContext.SelectedProperties | sort-object | Should Be ('Name', 'Company' | sort-object)
+            $responseContext.ExpandedProperties | sort-object | Should Be ('Address', 'Office' | sort-object)
             $responseContext.Root | Should Be 'Customers'
         }
 
@@ -324,8 +324,8 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be 'Customer.Wholesale'
             $responseContext.IsEntity | Should Be $false
-            $responseContext.SelectedProperties | sort | Should Be ('Name', 'Company' | sort)
-            $responseContext.ExpandedProperties | sort | Should Be ('Address', 'Office' | sort)
+            $responseContext.SelectedProperties | sort-object | Should Be ('Name', 'Company' | sort-object)
+            $responseContext.ExpandedProperties | sort-object | Should Be ('Address', 'Office' | sort-object)
             $responseContext.Root | Should Be 'Customers'
         }
 
@@ -375,8 +375,8 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsEntity | Should Be $true
-            $responseContext.SelectedProperties | sort | Should Be $null
-            $responseContext.ExpandedProperties | sort | Should Be ('DirectReports' | sort)
+            $responseContext.SelectedProperties | sort-object | Should Be $null
+            $responseContext.ExpandedProperties | sort-object | Should Be ('DirectReports' | sort-object)
             $responseContext.Root | Should Be 'Employees'
         }
 
@@ -393,8 +393,8 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be 'Sales.Manager'
             $responseContext.IsEntity | Should Be $true
-            $responseContext.SelectedProperties | sort | Should Be $null
-            $responseContext.ExpandedProperties | sort | Should Be ('DirectReports' | sort)
+            $responseContext.SelectedProperties | sort-object | Should Be $null
+            $responseContext.ExpandedProperties | sort-object | Should Be ('DirectReports' | sort-object)
             $responseContext.Root | Should Be 'Employees'
         }
 
@@ -411,8 +411,8 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsEntity | Should Be $false
-            $responseContext.SelectedProperties | sort | Should Be $null
-            $responseContext.ExpandedProperties | sort | Should Be ('DirectReports' | sort)
+            $responseContext.SelectedProperties | sort-object | Should Be $null
+            $responseContext.ExpandedProperties | sort-object | Should Be ('DirectReports' | sort-object)
             $responseContext.Root | Should Be 'me'
         }
 
@@ -429,8 +429,8 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be 'Sales.Manager'
             $responseContext.IsEntity | Should Be $false
-            $responseContext.SelectedProperties | sort | Should Be $null
-            $responseContext.ExpandedProperties | sort | Should Be ('DirectReports' | sort)
+            $responseContext.SelectedProperties | sort-object | Should Be $null
+            $responseContext.ExpandedProperties | sort-object | Should Be ('DirectReports' | sort-object)
             $responseContext.Root | Should Be $null
         }
 
@@ -485,8 +485,8 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsEntity | Should Be $false
-            $responseContext.SelectedProperties | sort | Should Be ('City', 'State' | sort)
-            $responseContext.ExpandedProperties | sort | Should Be $null
+            $responseContext.SelectedProperties | sort-object | Should Be ('City', 'State' | sort-object)
+            $responseContext.ExpandedProperties | sort-object | Should Be $null
             $responseContext.Root | Should Be 'Employees'
         }
 
@@ -509,7 +509,7 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be 'Sales.Manager'
             $responseContext.IsEntity | Should Be $false
-            $responseContext.SelectedProperties | sort | Should Be ( 'FirstName', 'LastName' | sort )
+            $responseContext.SelectedProperties | sort-object | Should Be ( 'FirstName', 'LastName' | sort-object )
             $responseContext.ExpandedProperties | Should Be $null
             $responseContext.Root | Should Be 'Employees'
             $responseContext.IsDelta | Should Be $true

--- a/src/common/ResponseContext.tests.ps1
+++ b/src/common/ResponseContext.tests.ps1
@@ -32,6 +32,7 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $null
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsEntity | Should Be $true
+            $responseContext.IsCollectionMember | Should Be $true
             $responseContext.Root | Should Be 'users'
         }
 
@@ -47,6 +48,7 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsEntity | Should Be $false
+            $responseContext.IsCollectionMember | Should Be $false
             $responseContext.Root | Should Be 'users'
         }
 
@@ -63,6 +65,7 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsEntity | Should Be $true
+            $responseContext.IsCollectionMember | Should Be $true
             $responseContext.Root | Should Be 'users'
         }
     }
@@ -81,6 +84,7 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $null
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsEntity | Should Be $false
+            $responseContext.IsCollectionMember | Should Be $false
             $responseContext.Root | Should Be $null
         }
 
@@ -96,10 +100,11 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $null
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsEntity | Should Be $false
+            $responseContext.IsCollectionMember | Should Be $false
             $responseContext.Root | Should Be $null
         }
 
-        It "Should correctly parse example 10.2 Collection of Entities - {context-url}#{entity=set}" {
+        It "Should correctly parse example 10.2 Collection of Entities - {context-url}#{entity-set}" {
             $requestUri = 'https://graph.microsoft.com/v1.0/users'
             $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#users'
 
@@ -112,6 +117,7 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsEntity | Should Be $false
+            $responseContext.IsCollectionMember | Should Be $true
             $responseContext.Root | Should Be 'users'
         }
 
@@ -128,6 +134,7 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be 'microsoft.graph.user'
             $responseContext.IsEntity | Should Be $false
+            $responseContext.IsCollectionMember | Should Be $true
             $responseContext.Root | Should Be 'users'
         }
 
@@ -144,6 +151,7 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsEntity | Should Be $true
+            $responseContext.IsCollectionMember | Should Be $true
             $responseContext.Root | Should Be 'users'
         }
 
@@ -160,23 +168,31 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be 'graph.user'
             $responseContext.IsEntity | Should Be $false
+            $responseContext.IsCollectionMember | Should Be $false
             $responseContext.Root | Should Be $null
         }
 
         It "Should correctly parse 10.4 Singleton - {context-url}#{singleton}" {
-            $requestUri = 'https://graph.microsoft.com/v1.0/me'
-            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#me'
+            # One issue with this case is that it turns out there is no way from the odata context and request uri
+            # alone to determine wither a context in this format is an entity set or a singleton -- you need to use
+            # the context to look up the item in the metadata document. This has implications for IsCollectionMember
+            # since we can't actually determine that this was returned as part of an entity set, which means it is a
+            # member of the entity set collection, or if it was just a singleton object that is not part of any
+            # collection.
+            $requestUri = 'https://graph.microsoft.com/v1.0/termStore'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#termStore'
 
             $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
 
-            $responseContext.GraphUri | Should Be '/me'
-            $responseContext.TypelessGraphUri | Should Be '/me'
-            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/me'
+            $responseContext.GraphUri | Should Be '/termStore'
+            $responseContext.TypelessGraphUri | Should Be '/termStore'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/termStore'
             $responseContext.ContextUrl | Should Be $contextUri
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsEntity | Should Be $false
-            $responseContext.Root | Should Be 'me'
+            $responseContext.IsCollectionMember | Should Be $true # This is not the desired behavior though, see above
+            $responseContext.Root | Should Be 'termStore'
         }
 
         It 'Should correctly parse 10.6 Derived Entity - {context-url}#{entity-set}{/type-name}/$entity' {
@@ -191,6 +207,7 @@ Describe 'ResponseContext class' {
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be 'Mail.User'
             $responseContext.IsEntity | Should Be $true
+            $responseContext.IsCollectionMember | Should Be $true
             $responseContext.Root | Should Be 'users'
         }
 
@@ -207,6 +224,7 @@ Describe 'ResponseContext class' {
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsEntity | Should Be $false
             $responseContext.SelectedProperties | sort-object | Should Be ('displayName', 'mail' | sort-object)
+            $responseContext.IsCollectionMember | Should Be $true
             $responseContext.Root | Should Be 'users'
         }
 
@@ -223,6 +241,7 @@ Describe 'ResponseContext class' {
             $responseContext.TypeCast | Should Be 'microsoft.graph.group'
             $responseContext.IsEntity | Should Be $false
             $responseContext.SelectedProperties | sort-object | Should Be ('displayName', 'id' | sort-object)
+            $responseContext.IsCollectionMember | Should Be $true
             $responseContext.Root | Should Be 'groups'
         }
 
@@ -239,6 +258,7 @@ Describe 'ResponseContext class' {
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsEntity | Should Be $true
             $responseContext.SelectedProperties | sort-object | Should Be ('displayName', 'mail' | sort-object)
+            $responseContext.IsCollectionMember | Should Be $true
             $responseContext.Root | Should Be 'users'
         }
 
@@ -256,24 +276,26 @@ Describe 'ResponseContext class' {
             $responseContext.TypeCast | Should Be 'microsoft.graph.user'
             $responseContext.IsEntity | Should Be $true
             $responseContext.SelectedProperties | sort-object | Should Be ('displayName', 'mail' | sort-object)
+            $responseContext.IsCollectionMember | Should Be $true
             $responseContext.Root | Should Be 'users'
         }
 
         It 'Should correctly parse 10.8 Projected Entity - {context-url}#{singleton}{select-list}' {
-            $requestUri = 'https://graph.microsoft.com/v1.0/me?$select=displayName,mail'
-            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#me(displayName,mail)'
+            $requestUri = 'https://graph.microsoft.com/v1.0/termStore?$select=defaultLanguageTag,languageTags'
+            $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#termStore(defaultLanguageTag,languageTags)/$entity'
 
             $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
 
-            $responseContext.GraphUri | Should Be '/me'
-            $responseContext.TypelessGraphUri | Should Be '/me'
-            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/me'
+            $responseContext.GraphUri | Should Be '/termStore'
+            $responseContext.TypelessGraphUri | Should Be '/termStore'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/termStore'
             $responseContext.ContextUrl | Should Be $contextUri
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be $null
-            $responseContext.IsEntity | Should Be $false
-            $responseContext.SelectedProperties | sort-object | Should Be ('displayName', 'mail' | sort-object)
-            $responseContext.Root | Should Be 'me'
+            $responseContext.IsEntity | Should Be $true
+            $responseContext.SelectedProperties | sort-object | Should Be ('defaultLanguageTag', 'languageTags' | sort-object)
+            $responseContext.IsCollectionMember | Should Be $true
+            $responseContext.Root | Should Be 'termStore'
         }
 
         It 'Should correctly parse 10.8 Projected Entity - {context-url}#{type-name}{select-list}' {
@@ -290,6 +312,7 @@ Describe 'ResponseContext class' {
             $responseContext.TypeCast | Should Be 'microsoft.graph.directoryObject'
             $responseContext.IsEntity | Should Be $false
             $responseContext.SelectedProperties | sort-object | Should Be ('displayName', 'mail' | sort-object)
+            $responseContext.IsCollectionMember | Should Be $false
             $responseContext.Root | Should Be $null
         }
 
@@ -308,6 +331,7 @@ Describe 'ResponseContext class' {
             $responseContext.IsEntity | Should Be $false
             $responseContext.SelectedProperties | sort-object | Should Be ('Name', 'Company' | sort-object)
             $responseContext.ExpandedProperties | sort-object | Should Be ('Address', 'Office' | sort-object)
+            $responseContext.IsCollectionMember | Should Be $true
             $responseContext.Root | Should Be 'Customers'
         }
 
@@ -326,6 +350,7 @@ Describe 'ResponseContext class' {
             $responseContext.IsEntity | Should Be $false
             $responseContext.SelectedProperties | sort-object | Should Be ('Name', 'Company' | sort-object)
             $responseContext.ExpandedProperties | sort-object | Should Be ('Address', 'Office' | sort-object)
+            $responseContext.IsCollectionMember | Should Be $false
             $responseContext.Root | Should Be 'Customers'
         }
 
@@ -344,6 +369,7 @@ Describe 'ResponseContext class' {
             $responseContext.IsEntity | Should Be $false
             $responseContext.SelectedProperties | Should Be @('Name')
             $responseContext.ExpandedProperties | Should Be @('Address')
+            $responseContext.IsCollectionMember | Should Be $true
             $responseContext.Root | Should Be 'Customers'
         }
 
@@ -377,6 +403,7 @@ Describe 'ResponseContext class' {
             $responseContext.IsEntity | Should Be $true
             $responseContext.SelectedProperties | sort-object | Should Be $null
             $responseContext.ExpandedProperties | sort-object | Should Be ('DirectReports' | sort-object)
+            $responseContext.IsCollectionMember | Should Be $true
             $responseContext.Root | Should Be 'Employees'
         }
 
@@ -395,25 +422,27 @@ Describe 'ResponseContext class' {
             $responseContext.IsEntity | Should Be $true
             $responseContext.SelectedProperties | sort-object | Should Be $null
             $responseContext.ExpandedProperties | sort-object | Should Be ('DirectReports' | sort-object)
+            $responseContext.IsCollectionMember | Should Be $true
             $responseContext.Root | Should Be 'Employees'
         }
 
         It 'Should correctly parse 10.10 Expanded Entity - {context-url}#{singleton}{select-list}' {
             $requestUri = 'https://host/service/me$expand=DirectReports($select=FirstName,LastName)'
-            $contextUri = 'https://host/service/$metadata#me(DirectReports+(FirstName,LastName))'
+            $contextUri = 'https://host/service/$metadata#users(DirectReports+(FirstName,LastName))/$entity'
 
             $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
 
-            $responseContext.GraphUri | Should Be '/me'
-            $responseContext.TypelessGraphUri | Should Be '/me'
-            $responseContext.AbsoluteGraphUri | Should Be 'https://host/service/me'
+            $responseContext.GraphUri | Should Be '/users'
+            $responseContext.TypelessGraphUri | Should Be '/users'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://host/service/users'
             $responseContext.ContextUrl | Should Be $contextUri
             $responseContext.RequestUrl | Should Be $requestUri
             $responseContext.TypeCast | Should Be $null
-            $responseContext.IsEntity | Should Be $false
+            $responseContext.IsEntity | Should Be $true
             $responseContext.SelectedProperties | sort-object | Should Be $null
             $responseContext.ExpandedProperties | sort-object | Should Be ('DirectReports' | sort-object)
-            $responseContext.Root | Should Be 'me'
+            $responseContext.IsCollectionMember | Should Be $true
+            $responseContext.Root | Should Be 'users'
         }
 
         It 'Should correctly parse 10.10 Expanded Entity - {context-url}#{type-name}{select-list}' {
@@ -431,6 +460,7 @@ Describe 'ResponseContext class' {
             $responseContext.IsEntity | Should Be $false
             $responseContext.SelectedProperties | sort-object | Should Be $null
             $responseContext.ExpandedProperties | sort-object | Should Be ('DirectReports' | sort-object)
+            $responseContext.IsCollectionMember | Should Be $false
             $responseContext.Root | Should Be $null
         }
 
@@ -453,7 +483,7 @@ Describe 'ResponseContext class' {
             $responseContext.IsReference | Should Be $true
         }
 
-        It 'Should correctly parse a context URI for 10.12 a single entity reference of the form {context-url}#$ref -- this means the context URL does not contain the type of the referenced entitiy' {
+        It 'Should correctly parse a context URI for 10.12 a single entity reference of the form {context-url}#$ref -- this means the context URL does not contain the type of the referenced entity' {
             $requestUri = 'https://host/service/Orders(10643)/Customer/$ref'
             $contextUri = 'https://host/service/$metadata#$ref'
 
@@ -469,6 +499,7 @@ Describe 'ResponseContext class' {
             $responseContext.SelectedProperties | Should Be $null
             $responseContext.ExpandedProperties | Should Be $null
             $responseContext.Root | Should Be $null
+            $responseContext.IsCollectionMember | Should Be $false
             $responseContext.IsReference | Should Be $true
         }
 
@@ -487,6 +518,7 @@ Describe 'ResponseContext class' {
             $responseContext.IsEntity | Should Be $false
             $responseContext.SelectedProperties | sort-object | Should Be ('City', 'State' | sort-object)
             $responseContext.ExpandedProperties | sort-object | Should Be $null
+            $responseContext.IsCollectionMember | Should Be $false
             $responseContext.Root | Should Be 'Employees'
         }
 
@@ -512,6 +544,7 @@ Describe 'ResponseContext class' {
             $responseContext.SelectedProperties | sort-object | Should Be ( 'FirstName', 'LastName' | sort-object )
             $responseContext.ExpandedProperties | Should Be $null
             $responseContext.Root | Should Be 'Employees'
+            $responseContext.IsCollectionMember | Should Be $false
             $responseContext.IsDelta | Should Be $true
         }
 
@@ -532,6 +565,7 @@ Describe 'ResponseContext class' {
             $responseContext.ExpandedProperties | Should Be $null
             $responseContext.Root | Should Be $null
             $responseContext.IsReference | Should Be $false
+            $responseContext.IsCollectionMember | Should Be $false
             $responseContext.IsDelta | Should Be $true
         }
 
@@ -549,6 +583,7 @@ Describe 'ResponseContext class' {
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsDeletedEntity | Should Be $true
             $responseContext.IsEntity | Should Be $false
+            $responseContext.IsCollectionMember | Should Be $false
             $responseContext.Root | Should Be 'users'
         }
 
@@ -566,6 +601,7 @@ Describe 'ResponseContext class' {
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsDeletedLink | Should Be $true
             $responseContext.IsEntity | Should Be $false
+            $responseContext.IsCollectionMember | Should Be $false
             $responseContext.Root | Should Be 'groups'
         }
 
@@ -583,6 +619,7 @@ Describe 'ResponseContext class' {
             $responseContext.TypeCast | Should Be $null
             $responseContext.IsNewLink | Should Be $true
             $responseContext.IsEntity | Should Be $false
+            $responseContext.IsCollectionMember | Should Be $false
             $responseContext.Root | Should Be 'groups'
         }
     }

--- a/src/graphservice/ApplicationAPI.ps1
+++ b/src/graphservice/ApplicationAPI.ps1
@@ -24,7 +24,7 @@ enum AppTenancy {
 
 ScriptClass ApplicationAPI {
     static {
-        const DefaultApplicationApiVersion beta
+        const DefaultApplicationApiVersion 'v1.0'
         $TenantToGraphServicePrincipal = @{}
     }
 

--- a/src/graphservice/ApplicationObject.ps1
+++ b/src/graphservice/ApplicationObject.ps1
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+. (import-script ../client/Application)
 . (import-script ../common/GraphApplicationCertificate)
 . (import-script ../common/ScopeHelper)
 . (import-script ../graphservice/ApplicationAPI)
@@ -76,7 +77,7 @@ ScriptClass ApplicationObject {
         $publicClientRedirectUris = if ( $redirectUris -ne $null ) {
             $redirectUris
         } else {
-            , @('urn:ietf:wg:oauth:2.0:oob')
+            , @($::.Application.DefaultRedirectUri)
         }
 
         $publicClient = [PSCustomObject] @{
@@ -91,7 +92,7 @@ ScriptClass ApplicationObject {
         $appRedirectUris = if ( $redirectUris ) {
             $redirectUris
         } else {
-            , @('http://localhost', 'urn:ietf:wg:oauth:2.0:oob')
+            , @($::.Application.DefaultRedirectUri)
         }
 
         $web = @{

--- a/src/graphservice/ApplicationObject.ps1
+++ b/src/graphservice/ApplicationObject.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019, Adam Edwards
+# Copyright 2020, Adam Edwards
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -85,6 +85,7 @@ ScriptClass ApplicationObject {
         }
 
         $app.Add('publicClient', $publicClient)
+        $app.Add('isFallbackPublicClient', $true)
     }
 
     function __SetConfidentialApp($app, $redirectUris) {


### PR DESCRIPTION
### Description

This release adds helper libraries for interpreting OData protocol response metadata, simplifies result paging capabilities, adds a detailed Graph response output format for applications building complex scenarios that require protocol awareness, and adds preview support for delta query.

### New dependencies

None.

### Breaking changes

* The `IncludeFullResponse` parameter is no longer supported by the `Invoke-GraphRequest` command. It has been superseded by the `AsResponseDetail` parameter added in this release.
* Applications created by New-GraphApplication no longer include 'http://localhost' and 'urn:ietf:wg:oauth:2.0:oob' by default. The only default URI specified for these application is 'https://login.microsoftonline.com/common/oauth2/nativeclient'.

### New features

* `Invoke-GraphRequest` has several new parameters to support delta query and improved control over result pagin:
  * `AsResponseDetail`: when specified, the output of the command rather than directly returning the deserialized objects from the Graph response instead returns a structure that includes a `Content` field that contains those objects. The other fields of the structure include additional details about the response, including conditionally populated fields such as `DeltaUri` and `DeltaToken` returned from delta query responses. The `Responses` field contains all of the detailed protocol responses from the graph that were issued as the command paged through result sets that required multiple requests to process.
  * `Delta`: when this is specified, the command issues a delta query to Graph, i.e. a query that in addition to returning the results specified in the query also returns additional metadata in the form of a "delta URI" or "delta token" that can be used in subsequent requests to return only the information that has changed since the original query. When this parameter is specified, the results are returned in the format used when `AsResponseDetail` is specified.
  * `DeltaToken`: This parameter provides a way to request only the incremental changes that would be returned compared to a previous request issued by this command using the Delta parameter.
  * `NoPaging`: This disables the default behavior of the command that issues multiple requests to Graph until all results for the initial request have been retrieved. When this command is specified, the results are returned using the `AsResponseDetail` format so that the caller has the additional information beyond the request results necessary to retrieve the additional results if desired.
  * `PageSizePreference`: directs the command to issues requests that instruct the Graph API to return a specific maximum number of items in each page of results. This parameter will only take effect if Graph honors it for the particular request.
  * `ResponseContext` class: This class parses the `ODataContext` property, an [OData Context URL](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_ContextURL) to return information about the type of the response and the URI used to make the request.
  * New methods in `GraphUtilities`:
    * `GetAbstractUriFromResponseObject` returns a close approximation of a URI that can be used to make a request for that response.
    * `GetOptionalTypeFromResponseObject` returns the parsed type from `@odata.type` for a given object if it is present
* AAD Application commands such as New-GraphApplication, Get-GraphApplication, Set-GraphApplicationConsent, etc., have been updated to use Graph API version v1.0 instead of beta since all application functionality is now present in v1.0.


### Fixed defects

* V2 public client authentication fails with mismatch reply URL when using a non-default app id unless localhost is configured as a reply url. The only workaround was to add localhost as a reply url to the app because no reply URL was specified by AutoGraphPS to the MSAL library when making the request. From an MSAL (and possibly from the protocol) standpoint, this is the equivalent of specifying no reply url. The fix is to specify whatever reply URL is configured in the local connection; by default, the app now uses 'https://login.microsoftonline.com/common/oauth2/nativeclient', which is now the default reply URL for applications created by New-GraphApplication.
* Get-GraphLog and related commands did not function correctly on PowerShell 7 -- error responses were logged with incomplete fields including an invalid http status code of 0. This was due to the underlying http client type being different on PowerShell 7 vs. PowerShell 5, and the methods and properties were different for this class, resulting in errors when trying to read data from the response. This seemed to only be an issue for error responses. The fix ensures that the type differences are accounted for on the different platforms and restores the error logging.
* Fixed an error where apps created by New-GraphApplication were registered such that device code authentication flow could not be used to sign-in with the apps. They were missing the fallbackPublicClient property for the app, which is apparently required for that flow to work. This is now fixed, and this restores device code flow login for these apps, which is critical for PowerShell 7 and later since they do not support the web browser controls used to sign in on PowerShell 5.


### Checklist

- [x] All project tests pass successfully