### PR TITLE
Correctly rename Remove-GraphItem to Remove-GraphResource

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The full list of cmdlets in this module is given below; note that `Invoke-GraphR
 | Remove-GraphApplication              | Deletes an Azure AD application                                                                                                                         |
 | Remove-GraphApplicationCertificate   | Removes a public key from the application for a certificate allowed to authenticate as that application                                                 |
 | Remove-GraphApplicationConsent       | Removes consent grants for an Azure AD application                                                                                                      |
-| Remove-GraphItem                     | Makes generic ``DELETE`` requests to a specified Graph URI to delete items                                                                              |
+| Remove-GraphResource                 | Makes generic ``DELETE`` requests to a specified Graph URI to delete resources                                                                          |
 | Set-GraphApplicationConsent          | Sets a consent grant for an Azure AD application                                                                                                        |
 | Set-GraphConnectionStatus            | Configures `Offline` mode for use with local commands like `GetGraphUri` or re-enables `Online` mode for accessing the Graph service                    |
 | Set-GraphLogOption                   | Sets the configuration options for logging of requests to Graph including options that control the detail level of the data logged                      |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,7 @@
 
 ## To-do items -- prioritized
 
+* Use a new appid hosted in a normal aad tenant rather than a consumer-initiated tenant
 * Make set-graphapplicationconsent idempotent (read grants / roles first, only add those that don't exist)
 * When invoke-graphrequest creates an object through post, it should add the id to the uri for the itemcontext
 * Add AllResults option to Get-GraphResource and Invoke-GraphRequest, and corresponding preference variable

--- a/autographps-sdk.psd1
+++ b/autographps-sdk.psd1
@@ -12,7 +12,7 @@
 RootModule = 'autographps-sdk.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.23.0'
+ModuleVersion = '0.24.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -94,7 +94,7 @@ FunctionsToExport = @(
     'Remove-GraphApplication'
     'Remove-GraphApplicationCertificate'
     'Remove-GraphApplicationConsent'
-    'Remove-GraphItem'
+    'Remove-GraphResource'
     'Set-GraphApplicationConsent'
     'Set-GraphConnectionStatus'
     'Set-GraphLogOption'
@@ -223,9 +223,9 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
-## AutoGraphPS-SDK 0.23.0 Release Notes
+## AutoGraphPS-SDK 0.24.0 Release Notes
 
-This release renames some commands that are already in use by modules commonly utilized by the community.
+This release renames the Remove-GraphItem command to Remove-GraphResource as it was intended to be named.
 
 ### New dependencies
 
@@ -233,10 +233,8 @@ None.
 
 ### Breaking changes
 
-* The following commands have been renamed:
-  `Connect-Graph => Connect-GraphApi`
-  `Disconnect-Graph => Disconnect-GraphApi`
-  `Invoke-GraphRequest => Invoke-GraphApiRequest`
+* The following command has been renamed:
+  `Remove-GraphItem => Remove-GraphResource`
 
 ### New features
 

--- a/autographps-sdk.psm1
+++ b/autographps-sdk.psm1
@@ -41,7 +41,7 @@ $cmdlets = @(
     'Remove-GraphApplication'
     'Remove-GraphApplicationCertificate'
     'Remove-GraphApplicationConsent'
-    'Remove-GraphItem'
+    'Remove-GraphResource'
     'Set-GraphApplicationConsent'
     'Set-GraphConnectionStatus'
     'Set-GraphLogOption'

--- a/autographps-sdk.tests.ps1
+++ b/autographps-sdk.tests.ps1
@@ -55,14 +55,12 @@ Describe "Poshgraph application" {
                 'Remove-GraphApplication',
                 'Remove-GraphApplicationCertificate',
                 'Remove-GraphApplicationConsent',
-                'Remove-GraphItem',
+                'Remove-GraphResource',
                 'Set-GraphApplicationConsent',
                 'Set-GraphConnectionStatus',
                 'Set-GraphLogOption',
                 'Test-Graph',
                 'Unregister-GraphApplication')
-
-            $manifest.FunctionsToExport.count | Should BeExactly $expectedFunctions.length
 
             $verifiedExportsCount = 0
 
@@ -70,9 +68,30 @@ Describe "Poshgraph application" {
                 if ( $manifest.FunctionsToExport -contains $_ ) {
                     $verifiedExportsCount++
                 }
+
+                { get-command $_ | out-null } | Should Not Throw
             }
 
+            $manifest.FunctionsToExport.count | Should BeExactly $expectedFunctions.length
+
             $verifiedExportsCount | Should BeExactly $expectedFunctions.length
+        }
+
+        It "should export the exact same set of aliases as are in the set of expected aliases" {
+            $expectedAliases = @('gge', 'ggr', 'gcat', 'Get-GraphContent', 'ggl', 'fgl')
+
+            $manifest.AliasesToExport.count | Should BeExactly $expectedAliases.length
+
+            $verifiedExportsCount = 0
+
+            $expectedAliases | foreach {
+                if ( $manifest.AliasesToExport -contains $_ ) {
+                    $verifiedExportsCount++
+                }
+                $_ | get-alias | select -expandproperty resolvedcommandname | get-command | select -expandproperty module | select -expandproperty name | Should Be $manifest.Name
+            }
+
+            $verifiedExportsCount | Should BeExactly $expectedAliases.length
         }
 
         It "Should export the exact same set of variables that are in the set of expected variables" {

--- a/src/cmdlets.ps1
+++ b/src/cmdlets.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019, Adam Edwards
+# Copyright 2020, Adam Edwards
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/cmdlets/Get-GraphError.ps1
+++ b/src/cmdlets/Get-GraphError.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019, Adam Edwards
+# Copyright 2020, Adam Edwards
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ The operator can then correct the error in the original Invoke-GraphApiRequest c
 .LINK
 Get-GraphResource
 Invoke-GraphApiRequest
-Remove-GraphItem
+Remove-GraphResource
 #>
 function Get-GraphError {
     [cmdletbinding()]

--- a/src/cmdlets/Remove-GraphResource.ps1
+++ b/src/cmdlets/Remove-GraphResource.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019, Adam Edwards
+# Copyright 2020, Adam Edwards
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,13 +21,13 @@
 Deletes resources such as users, groups, drive items, or any other resource from the Graph.
 
 .DESCRIPTION
-The Remove-GraphItem command issues a DELETE request against the URI for one or more Graph objects; if successful, any such objects will be deleted from the Graph according to Graph REST API semantics.
+The Remove-GraphResource command issues a DELETE request against the URI for one or more Graph objects; if successful, any such objects will be deleted from the Graph according to Graph REST API semantics.
 
 .PARAMETER Uri
 If this parameter is specified and the TargetItem parameter is not specified, this Uri specifies a URI relative to the current Graph's API version. For example, if the current Graph endpoint is https://graph.microsoft.com and the API version is v1.0, a Uri parameter of 'users/user1@domain.org' specifies that this command must delete the object at https://graph.microsoft.com/v1.0/users/user1@domain.org. Note that the version may be overridden by the Version parameter (see the documentation for Version below). If the AbsoluteUri parameter is specified, the Uri parameter must be an absolute Uri (see the AbsoluteUri documentation below). If TargetItem is specified, the Uri parameter is interpreted as the "parent" of the objects to delete -- see the documentation for the TargetItem parameter.
 
 .PARAMETER TargetItem
-TargetItem may be any object returned by Get-GraphResource or Invoke-GraphApiRequest. Remove-GraphItem will attempt to delete that object from the Graph. If both Uri and TargetItem are specified, the Uri and TargetItem parameters are intepreted together as the path of the item to delete, i.e. for each specified TargetItem, a relative URI consisting of the Uri parameter succeeded with a segment named with the TargetItem object's id property. The TargetItem parameter accepts one or more objects from the pipeline as objects to delete.
+TargetItem may be any object returned by Get-GraphResource or Invoke-GraphApiRequest. Remove-GraphResource will attempt to delete that object from the Graph. If both Uri and TargetItem are specified, the Uri and TargetItem parameters are intepreted together as the path of the item to delete, i.e. for each specified TargetItem, a relative URI consisting of the Uri parameter succeeded with a segment named with the TargetItem object's id property. The TargetItem parameter accepts one or more objects from the pipeline as objects to delete.
 
 .PARAMETER Filter
 Specifies a filter using the OData specification to filter the items to be deleted from the Uri or TargetItem that is specified. This parameter may not be supported by all Graph Uris.
@@ -54,7 +54,7 @@ Specifies that for this command invocation, an access token with delegated permi
 None.
 
 .EXAMPLE
-Remove-GraphItem groups/19f1afdc-376c-48b7-9125-54ac8e73e3a3
+Remove-GraphResource groups/19f1afdc-376c-48b7-9125-54ac8e73e3a3
 
 Confirm
 Are you sure you want to perform this action?
@@ -64,16 +64,16 @@ Performing the operation "DELETE" on target "groups/19f1afdc-376c-48b7-9125-54ac
 This example removes the group object with ID 19f1afdc-376c-48b7-9125-54ac8e73e3a3; it ultimately makes a DELETE request against the URI https://graph.microsoft.com/v1.0/groups/19f1afdc-376c-48b7-9125-54ac8e73e3a3. By default, the command asks for confirmation, so a prompt was displayed that requires the user to enter "A" or "Y" to proceed.
 
 .EXAMPLE
-Get-GraphResource user/26a733c2-e87f-4030-a128-a8968c6ee204 | Remove-GraphItem -Confirm:$false
+Get-GraphResource user/26a733c2-e87f-4030-a128-a8968c6ee204 | Remove-GraphResource -Confirm:$false
 
-This example pipes the output of Get-GraphResource for a user object to Remove-GraphItem. This results in the deletion of that user object. Because the Confirm option was specified with the value '$false", no confirmation prompt was displayed and the command proceeded to delete the target without further user interaction.
+This example pipes the output of Get-GraphResource for a user object to Remove-GraphResource. This results in the deletion of that user object. Because the Confirm option was specified with the value '$false", no confirmation prompt was displayed and the command proceeded to delete the target without further user interaction.
 
 Get-GraphResource
 Invoke-GraphApiRequest
 New-GraphConnection
 Connect-GraphApi
 #>
-function Remove-GraphItem {
+function Remove-GraphResource {
     [cmdletbinding(supportsshouldprocess=$true, confirmimpact='High', positionalbinding=$false)]
     param(
         [parameter(position=0)]
@@ -177,6 +177,5 @@ function Remove-GraphItem {
     end {}
 }
 
-$::.ParameterCompleter |=> RegisterParameterCompleter Remove-GraphItem Permissions (new-so PermissionParameterCompleter ([PermissionCompletionType]::AnyPermission))
-
+$::.ParameterCompleter |=> RegisterParameterCompleter Remove-GraphResource Permissions (new-so PermissionParameterCompleter ([PermissionCompletionType]::AnyPermission))
 


### PR DESCRIPTION
### Description

This release renames the Remove-GraphItem command to Remove-GraphResource as it was intended to be named.

### New dependencies

None.

### Breaking changes

* The following command has been renamed:
  `Remove-GraphItem => Remove-GraphResource`

### New features

None.

### Fixed defects

- [ ] All project tests pass successfully
