### PR TITLE
MSA regression fix, authentication improvements, other fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you're using a script module (`.psm1` file) or simply a plain PowerShell `ps1
 
 ## Reference
 
-The full list of cmdlets in this module is given below; note that `Invoke-GraphRequest` may be used not just for reading from the Graph, but also for write operations. Use `Connect-GraphApi` to request additional permissions as described in the [Graph permissions documentation](https://developer.microsoft.com/en-us/graph/docs/concepts/permissions_reference). Additional cmdlets will be added to this module as development matures.
+The full list of cmdlets in this module is given below; note that `Invoke-GraphRequest` may be used not just for reading from the Graph, but also for write operations. Use `Connect-GraphApi` to request additional permissions as described in the [Graph permissions documentation](https://docs.microsoft.com/en-us/graph/permissions-reference).
 
 | Cmdlet (alias)                       | Description                                                                                                                                             |
 |--------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/autographps-sdk.nuspec
+++ b/autographps-sdk.nuspec
@@ -24,8 +24,8 @@
     <file src="autographps-sdk.tests.ps1" target="." />
     <file src="src\**\*.ps1" target="src/" />
     <file src="build\**\*.ps1" target="build/" />
-    <file src="lib\Microsoft.Identity.Client.4.14.0\lib\net45\*.dll" target="lib/Microsoft.Identity.Client.4.14.0\lib\net45" />
-    <file src="lib\Microsoft.Identity.Client.4.14.0\lib\netstandard1.3\*.dll" target="lib/Microsoft.Identity.Client.4.14.0\lib\netstandard1.3" />
+    <file src="lib\Microsoft.Identity.Client.4.27.0\lib\net45\*.dll" target="lib/Microsoft.Identity.Client.4.27.0\lib\net45" />
+    <file src="lib\Microsoft.Identity.Client.4.27.0\lib\netstandard1.3\*.dll" target="lib/Microsoft.Identity.Client.4.27.0\lib\netstandard1.3" />
     <file src="lib\Microsoft.IdentityModel.Clients.ActiveDirectory.5.2.7\lib\net45\*.dll" target="lib/Microsoft.IdentityModel.Clients.ActiveDirectory.5.2.7\lib\net45" />
     <file src="lib\Microsoft.IdentityModel.Clients.ActiveDirectory.5.2.7\lib\netstandard1.3\*.dll" target="lib/Microsoft.IdentityModel.Clients.ActiveDirectory.5.2.7\lib\netstandard1.3" />
   </files>

--- a/autographps-sdk.psd1
+++ b/autographps-sdk.psd1
@@ -27,10 +27,10 @@ Author = 'Adam Edwards'
 CompanyName = 'Modulus Group'
 
 # Copyright statement for this module
-Copyright = '(c) 2020 Adam Edwards.'
+Copyright = '(c) 2021 Adam Edwards.'
 
 # Description of the functionality provided by this module
-Description = 'PowerShell SDK for automating the Microsoft Graph'
+Description = 'PowerShell SDK for Microsoft Graph automation'
 
 # Minimum version of the Windows PowerShell engine required by this module
 PowerShellVersion = '5.1'
@@ -241,6 +241,7 @@ None.
 ### New features
 
 * `Connect-GraphApi` and `New-GraphConnection` support the `AllowMSA` parameter to enable MSA accounts when signing in with an app other than the default app
+* Objects emitted by `Invoke-GraphApiRequest` and related commands now have a type `GraphResponseObject` included in `PSTypeNames` to enable reliable pipeline binding and eventual improvements in output formatting.
 
 None.
 
@@ -248,6 +249,8 @@ None.
 
 * [Many scenarios broken for Microsoft Accounts only but not broken for AAD accounts](https://github.com/adamedx/autographps-sdk/issues/53)
 * Sign-in for single tenant applications was broken
+* Error response streams were not being retrieved, so detailed errors were missing from Get-GraphLog and other error-surfacing mechanisms
+* `Get-GraphLog` was emitting errors in the wrong order with oldest first rather than newest first
 
 '@
 

--- a/autographps-sdk.psd1
+++ b/autographps-sdk.psd1
@@ -234,13 +234,20 @@ None.
 
 ### Breaking changes
 
+* Old default appid is deprecated, superseded with new appid ac70e3e2-a821-4d19-839c-b8af4515254b
+* When signing in with an app other than the default appid, personal Microsoft Accounts cannot sign in without specifying `AllowMSA` via `Connect-GraphApi`
+* `New-GraphApplication` now creates single tenant applications by default for public client apps
+
 ### New features
+
+* `Connect-GraphApi` and `New-GraphConnection` support the `AllowMSA` parameter to enable MSA accounts when signing in with an app other than the default app
 
 None.
 
 ### Fixed defects
 
 * [Many scenarios broken for Microsoft Accounts only but not broken for AAD accounts](https://github.com/adamedx/autographps-sdk/issues/53)
+* Sign-in for single tenant applications was broken
 
 '@
 

--- a/autographps-sdk.psd1
+++ b/autographps-sdk.psd1
@@ -12,7 +12,7 @@
 RootModule = 'autographps-sdk.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.24.0'
+ModuleVersion = '0.25.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -223,9 +223,10 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
-## AutoGraphPS-SDK 0.24.0 Release Notes
+## AutoGraphPS-SDK 0.25.0 Release Notes
 
-This release renames the Remove-GraphItem command to Remove-GraphResource as it was intended to be named.
+This release addresses a major regression for Microsoft Accounts only (not Azure Active Directory accounts) and
+updates authentication parameters to best practices.
 
 ### New dependencies
 
@@ -233,14 +234,13 @@ None.
 
 ### Breaking changes
 
-* The following command has been renamed:
-  `Remove-GraphItem => Remove-GraphResource`
-
 ### New features
 
 None.
 
 ### Fixed defects
+
+* [Many scenarios broken for Microsoft Accounts only but not broken for AAD accounts](https://github.com/adamedx/autographps-sdk/issues/53)
 
 '@
 

--- a/autographps-sdk.psd1
+++ b/autographps-sdk.psd1
@@ -225,8 +225,8 @@ PrivateData = @{
         ReleaseNotes = @'
 ## AutoGraphPS-SDK 0.25.0 Release Notes
 
-This release addresses a major regression for Microsoft Accounts only (not Azure Active Directory accounts) and
-updates authentication parameters to best practices.
+This release addresses a major regression for Microsoft Accounts only (not Azure Active Directory accounts),
+updates authentication parameters to best practices, and includes minor bug fixes and improvements.
 
 ### New dependencies
 
@@ -242,8 +242,6 @@ None.
 
 * `Connect-GraphApi` and `New-GraphConnection` support the `AllowMSA` parameter to enable MSA accounts when signing in with an app other than the default app
 * Objects emitted by `Invoke-GraphApiRequest` and related commands now have a type `GraphResponseObject` included in `PSTypeNames` to enable reliable pipeline binding and eventual improvements in output formatting.
-
-None.
 
 ### Fixed defects
 

--- a/autographps-sdk.psd1
+++ b/autographps-sdk.psd1
@@ -234,7 +234,7 @@ None.
 
 ### Breaking changes
 
-* Old default appid is deprecated, superseded with new appid ac70e3e2-a821-4d19-839c-b8af4515254b
+* Old default appid is deprecated, superseded with new appid ac70e3e2-a821-4d19-839c-b8af4515254b. Impact includes the need to re-consent to any desired permissions that were granted to the previous appid.
 * When signing in with an app other than the default appid, personal Microsoft Accounts cannot sign in without specifying `AllowMSA` via `Connect-GraphApi`
 * `New-GraphApplication` now creates single tenant applications by default for public client apps
 

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="5.2.7" targetFramework="net45" />
-  <package id="Microsoft.Identity.Client" version="4.14.0" targetFramework="net45" />
+  <package id="Microsoft.Identity.Client" version="4.27.0" targetFramework="net45" />
 </packages>

--- a/src/REST/RESTResponse.ps1
+++ b/src/REST/RESTResponse.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019, Adam Edwards
+# Copyright 2021, Adam Edwards
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,11 +50,14 @@ ScriptClass RESTResponse {
         function GetErrorResponseDetails($response) {
             if ( $response -ne $null ) {
                 $responseType = $response.GetType()
-                $responseStream = switch ( $responseType ) {
-                    [System.Net.WebResponse] {
-                        $responseStream = $response.getresponsestream()
+                $responseStream = switch ( $responseType.FullName ) {
+                    'System.Net.WebResponse' {
+                        $response.getresponsestream()
                     }
-                    [System.Net.Http.HttpResponseMessage] {
+                    'System.Net.HttpWebResponse' {
+                        $response.getresponsestream()
+                    }
+                    'System.Net.Http.HttpResponseMessage' {
                         # No need to read the stream for this type, so
                         # we won't return it
                     }

--- a/src/client/Application.ps1
+++ b/src/client/Application.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019, Adam Edwards
+# Copyright 2020, Adam Edwards
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 ScriptClass Application {
     static {
-        const DefaultAppId (strict-val [Guid] '9825d80c-5aa0-42ef-bf13-61e12116704c')
+        const DefaultAppId (strict-val [Guid] 'ac70e3e2-a821-4d19-839c-b8af4515254b')
         const DefaultRedirectUri 'https://login.microsoftonline.com/common/oauth2/nativeclient'
         $SupportsBrowserSignin = $PSVersionTable.PSEdition -eq 'Desktop'
     }

--- a/src/client/GraphConnection.ps1
+++ b/src/client/GraphConnection.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019, Adam Edwards
+# Copyright 2020, Adam Edwards
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -104,11 +104,11 @@ ScriptClass GraphConnection {
     }
 
     static {
-        function NewSimpleConnection([string] $graphType = 'MSGraph', [string] $cloud = 'Public', [String[]] $ScopeNames, $anonymous = $false, $tenantName = $null, $authProtocol = $null, $userAgent = $null ) {
+        function NewSimpleConnection([string] $graphType = 'MSGraph', [string] $cloud = 'Public', [String[]] $ScopeNames, $anonymous = $false, $tenantName = $null, $authProtocol = $null, $userAgent = $null, $allowMSA = $true ) {
             $endpoint = new-so GraphEndpoint $cloud $graphType $null $null $authProtocol
             $app = new-so GraphApplication $::.Application.DefaultAppId
             $identity = if ( ! $anonymous ) {
-                new-so GraphIdentity $app $endpoint $tenantName
+                new-so GraphIdentity $app $endpoint $tenantName $allowMSA
             }
 
             new-so GraphConnection $endpoint $identity $ScopeNames $false $userAgent

--- a/src/cmdlets/Connect-GraphApi.ps1
+++ b/src/cmdlets/Connect-GraphApi.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019, Adam Edwards
+# Copyright 2020, Adam Edwards
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -107,6 +107,11 @@ function Connect-GraphApi {
         [parameter(parametersetname='customendpoint')]
         [ValidateSet('v1', 'v2', 'Default')]
         [String] $AuthProtocol = 'Default',
+
+        [parameter(parametersetname='msgraph')]
+        [parameter(parametersetname='customendpoint')]
+        [ValidateSet('Auto', 'AzureADOnly', 'AzureADAndPersonalMicrosoftAccount')]
+        [string] $AccountType = 'Auto',
 
         [parameter(parametersetname='aadgraph', mandatory=$true)]
         [parameter(parametersetname='customendpoint')]

--- a/src/cmdlets/Format-GraphLog.ps1
+++ b/src/cmdlets/Format-GraphLog.ps1
@@ -246,7 +246,11 @@ function Format-GraphLog {
         }
 
         if ( $errorSimpleIncluded -and $errorMessage ) {
-            $errorAsObject = $errorMessage | convertfrom-json -erroraction ignore
+            $errorAsObject = try {
+                # Apparently action ignore still results in errors at times
+                $errorMessage | convertfrom-json -erroraction ignore
+            } catch {
+            }
 
             $simpleErrorMessage = if ( $errorAsObject ) {
                 $errorMember = if ( $errorAsObject | gm error -erroraction ignore ) {

--- a/src/cmdlets/Get-GraphLog.ps1
+++ b/src/cmdlets/Get-GraphLog.ps1
@@ -150,10 +150,11 @@ function Get-GraphLog {
     $filterFlag = if ( $StatusFilter -ne 'None' ) { $StatusFilter -eq 'Error' }
     $results = ($::.RequestLog |=> GetDefault) |=> GetLogEntries $Skip $count $fromOldest $All.IsPresent $filterFlag
 
-    # Results are sorted in reverse chronological order if enumerating from newest -- reverse this
-    # so that we always return results in chronological order as part of a standard ux convention
+    # Results are sorted in reverse chronological order if enumerating from newest, but the reverse
+    # is true for sorting from oldest. To ensure that for oldest the newest retrieved record is first,
+    # reverse this so that we always return results in chronological order as part of a standard ux convention
     if ( $results ) {
-        if ( ! $fromOldest -and ( $results -is [object[]] ) ) {
+        if ( $fromOldest -and ( $results -is [object[]] ) ) {
             $start = 0
             $end = $results.length - 1
             while ( $start -lt $end ) {

--- a/src/cmdlets/New-GraphApplication.ps1
+++ b/src/cmdlets/New-GraphApplication.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019, Adam Edwards
+# Copyright 2020, Adam Edwards
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -107,11 +107,7 @@ function New-GraphApplication {
     $computedTenancy = if ( $Tenancy -ne ([AppTenancy]::Auto) ) {
         $Tenancy
     } else {
-        if( $Confidential.IsPresent ) {
-            [AppTenancy]::SingleTenant
-        } else {
-            [AppTenancy]::AnyTenant
-        }
+        [AppTenancy]::SingleTenant
     }
 
     $appAPI = new-so ApplicationAPI $commandContext.Connection $commandContext.Version

--- a/src/cmdlets/common/ItemResultHelper.ps1
+++ b/src/cmdlets/common/ItemResultHelper.ps1
@@ -121,7 +121,16 @@ ScriptClass ItemResultHelper -ArgumentList $__DefaultResultVariable {
                 }
 "@
 
-            [ScriptBlock]::Create($scriptText)
+            # In case of unpredictable issues with the context uri response from Graph,
+            # fall back to a simpler implementation of ItemContext that simply includes
+            # the original request uri
+            $script = try {
+                [ScriptBlock]::Create($scriptText)
+            } catch {
+                [ScriptBlock]::Create("[PSCustomObject] @{RequestUri=`"$requestUriNoQuery`"}")
+            }
+
+            $script
         }
 
         function SetItemContext([object[]] $items, [ScriptBlock] $contextScript) {

--- a/src/cmdlets/common/ItemResultHelper.ps1
+++ b/src/cmdlets/common/ItemResultHelper.ps1
@@ -136,6 +136,7 @@ ScriptClass ItemResultHelper -ArgumentList $__DefaultResultVariable {
         function SetItemContext([object[]] $items, [ScriptBlock] $contextScript) {
             $items | foreach {
                 $_ | add-member -membertype scriptmethod -name __ItemContext -value $contextScript
+                $_.pstypenames.Add('GraphResponseObject')
             }
         }
     }

--- a/src/common/ResponseContext.ps1
+++ b/src/common/ResponseContext.ps1
@@ -310,9 +310,8 @@ ScriptClass ResponseContext {
             $selectList = $parsedParameters.SelectList
             $parameterString = $parsedParameters.Parameters
 
-            # This may be a type cast -- if so, it has a qualified name,
-            # which always has a '.', so look for that to identify the cast
-            if ( $matches.name.Contains('.') ) {
+            # This may be a type cast
+            if ( __IsTypeCast $matches.name ) {
                 $parsedSelect = __ParseSelectList $parameterString
                 $selectedProperties = $parsedSelect.SelectedProperties
                 $expandedProperties = $parsedSelect.ExpandedProperties
@@ -321,7 +320,7 @@ ScriptClass ResponseContext {
             } else {
                 $name = $matches.name
 
-                if ( $parameterString.Contains('.') ) {
+                if ( __IsTypeCast $parameterString ) {
                     $parsedSelect = __ParseSelectList $selectList
                     $selectedProperties = $parsedSelect.SelectedProperties
                     $expandedProperties = $parsedSelect.ExpandedProperties
@@ -348,7 +347,7 @@ ScriptClass ResponseContext {
             }
         } else {
             # There are no parameters, the name is just the segment or a type cast
-            if ( $segment.Contains('.') ) {
+            if ( __IsTypeCast $segment ) {
                 $typeCast = $segment
                 $typeCastOnly = $true
             } else {
@@ -367,6 +366,15 @@ ScriptClass ResponseContext {
                 IsRefCollection = $isRefCollection
             }
         }
+    }
+
+    function __IsTypeCast($name) {
+        # See if this is a type cast -- if so, it has a qualified name,
+        # which always has a '.', so look for that to identify the cast --
+        # also make, sure it doesn't have a "'" character which would indicate its
+        # actually an id, e.g. part of a uri like
+        # https://graph.microsoft.com/v1.0/$metadata#users('adamedw@hotmail.com')/contacts
+        $name.Contains('.') -and ! $name.StartsWith("'")
     }
 
     function __ParseParameters($parameterString) {

--- a/src/common/ResponseContext.tests.ps1
+++ b/src/common/ResponseContext.tests.ps1
@@ -138,6 +138,23 @@ Describe 'ResponseContext class' {
             $responseContext.Root | Should Be 'users'
         }
 
+        It "Should not confuse a quoted id with a typecast as in the case of 10.2 Collection of Entities - {context-url}#Collection({type-name})" {
+            $requestUri = 'https://graph.microsoft.com/v1.0/me/contacts'
+            $contextUri = "https://graph.microsoft.com/v1.0/$metadata#users('myuser@mydomain.com')/contacts"
+
+            $responseContext = new-so ResponseContext $requestUri $contextUri |=> ToPublicContext
+
+            $responseContext.GraphUri | Should Be '/users/myuser@mydomain.com/contacts'
+            $responseContext.TypelessGraphUri | Should Be '/users/myuser@mydomain.com/contacts'
+            $responseContext.AbsoluteGraphUri | Should Be 'https://graph.microsoft.com/v1.0/users/myuser@mydomain.com/contacts'
+            $responseContext.ContextUrl | Should Be $contextUri
+            $responseContext.RequestUrl | Should Be $requestUri
+            $responseContext.TypeCast | Should Be $null
+            $responseContext.IsEntity | Should Be $false
+            $responseContext.IsCollectionMember | Should Be $false
+            $responseContext.Root | Should Be 'users'
+        }
+
         It 'Should correctly parse 10.3 Entity - {context-url}#{entity-set}/$entity' {
             $requestUri = 'https://graph.microsoft.com/v1.0/users/userid'
             $contextUri = 'https://graph.microsoft.com/v1.0/$metadata#users/$entity'

--- a/src/graphservice/GraphEndpoint.ps1
+++ b/src/graphservice/GraphEndpoint.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019, Adam Edwards
+# Copyright 2020, Adam Edwards
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -141,11 +141,13 @@ ScriptClass GraphEndpoint {
         $this.GraphResourceUri = if ( $graphResourceUri ) { $graphResourceUri } else { $this.Graph }
     }
 
-    function GetAuthUri($tenantName) {
-        $tenantSegment = if ( ! $TenantName ) {
+    function GetAuthUri($tenantName, $allowMSA) {
+        $tenantSegment = if ( $allowMSA -and ! $tenantName ) {
             'common'
-        } else {
+        } elseif ( $tenantName ) {
             $tenantName
+        } else {
+            'organizations'
         }
 
         $components = @($this.Authentication.tostring().trimend('/'))


### PR DESCRIPTION
### Description
This release addresses a major regression for Microsoft Accounts only (not Azure Active Directory accounts),
updates authentication parameters to best practices, and includes minor bug fixes and improvements.

### New dependencies

None.

### Breaking changes

* Old default appid is deprecated, superseded with new appid ac70e3e2-a821-4d19-839c-b8af4515254b. Impact includes the need to re-consent to any desired permissions that were granted to the previous appid.
* When signing in with an app other than the default appid, personal Microsoft Accounts cannot sign in without specifying `AllowMSA` via `Connect-GraphApi`
* `New-GraphApplication` now creates single tenant applications by default for public client apps

### New features

* `Connect-GraphApi` and `New-GraphConnection` support the `AllowMSA` parameter to enable MSA accounts when signing in with an app other than the default app
* Objects emitted by `Invoke-GraphApiRequest` and related commands now have a type `GraphResponseObject` included in `PSTypeNames` to enable reliable pipeline binding and eventual improvements in output formatting.

### Fixed defects

* [Many scenarios broken for Microsoft Accounts only but not broken for AAD accounts](https://github.com/adamedx/autographps-sdk/issues/53)
* Sign-in for single tenant applications was broken
* Error response streams were not being retrieved, so detailed errors were missing from Get-GraphLog and other error-surfacing mechanisms
* `Get-GraphLog` was emitting errors in the wrong order with oldest first rather than newest first


### Checklist

- [x] All project tests pass successfully
<https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
