### PR TITLE
Update pipeline image to ubunut-latest from ubuntu-16.04 to avoid deprecation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
         OS_PLATFORM: 'windows'
         USE_POWERSHELL_CORE: true
       PowerShellCoreUbuntu:
-        VM_IMAGE: 'ubuntu-16.04'
+        VM_IMAGE: 'ubuntu-latest'
         OS_PLATFORM: 'ubuntu'
         USE_POWERSHELL_CORE: true
   pool:

--- a/src/cmdlets/Test-Graph.tests.ps1
+++ b/src/cmdlets/Test-Graph.tests.ps1
@@ -80,7 +80,7 @@ Describe "The Test-Graph command" {
         It "should return a result with expected members" {
             $testResult = Test-Graph
             $testResult.NonfatalStatus | Should Be $endpointBehavior.ExpectedStatus
-            $testResult.ServerTimestamp.ToString() | Should Be '9/19/2021 5:53:33 AM +00:00'
+            $testResult.ServerTimestamp | Should Be ([DateTimeOffset]::Parse('9/19/2021 5:53:33 AM +00:00'))
             ($testResult.ClientRequestTimestamp.GetType()) | Should BeExactly ([DateTimeOffset])
             ($testResult.ClientResponseTimestamp.GetType()) | Should BeExactly ([DateTimeOffset])
             $testResult.RequestId | Should Be 'b2c212c9-bf31-49cb-af50-5cd93948c85f'
@@ -96,7 +96,7 @@ Describe "The Test-Graph command" {
             $endpointBehavior.ExpectedStatus = 200
             $testResult = Test-Graph
             $testResult.NonfatalStatus | Should Be $endpointBehavior.ExpectedStatus
-            $testResult.ServerTimestamp.ToString() | Should Be '9/19/2021 5:53:33 AM +00:00'
+            $testResult.ServerTimestamp.ToString() | Should Be ([DateTimeOffset]::Parse('9/19/2021 5:53:33 AM +00:00'))
             ($testResult.ClientRequestTimestamp.GetType()) | Should BeExactly ([DateTimeOffset])
             ($testResult.ClientResponseTimestamp.GetType()) | Should BeExactly ([DateTimeOffset])
             $testResult.RequestId | Should Be 'b2c212c9-bf31-49cb-af50-5cd93948c85f'


### PR DESCRIPTION
### Description

Azure Pipelines is deprecating the ubuntu-16.04 image used by this repository, update it to ubuntu-latest.

### Dependency changes

None.

### Checklist

- [x] All project tests pass successfully
