### PR TITLE
Fix broken graph removal impacting downstream `Remove-Graph` command

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -485,6 +485,7 @@
 * Normalize command parameters for consent across all commands
 * Fix empty sets with get-graphresource returning non-null object
 * Remove nuget.exe and nuspec from build process, use only modern csproj and dotnet tool
+* Fix Remove-Graph bug in RemoveContext method of LogicalGraphManager
 
 ### Postponed
 

--- a/autographps-sdk.psd1
+++ b/autographps-sdk.psd1
@@ -12,7 +12,7 @@
 RootModule = 'autographps-sdk.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.30.0'
+ModuleVersion = '0.31.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -247,34 +247,24 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
-## AutoGraphPS-SDK 0.30.0 Release Notes
+## AutoGraphPS-SDK 0.31.0 Release Notes
 
-Add integration testing to CI pipeline, sample code documentation generation, and fix some code defects.
+Fix important code defects.
 
 ### New dependencies
 
-* ScriptClass 0.20.3
 
 ### Breaking changes
 
-* Renamed the `PrincipalIdToConsent` parameter to `ConsentedPrincipalId` in the commands `New-GraphApplication`, `RegisterGraphApplication`, and `Set-GraphApplicationConsent` for consistency with other commands referencing the same concept.
+None.
 
 ### New features
 
-* `GraphResponseObject` pstypename added to `Get-GraphApplication` and `New-GraphApplication` commands to support pipelines that accept `GraphResponseObject` (including commands outside this module).
-* Added `Tags` parameter to `Get-GraphApplication` to search by the tags property
+None.
 
 ### Fixed defects
 
-* Fixed missing prompt for certificate credentials and failure to configure the certificate credentials when using `CertificateFilePath` or `CertificatePath` parameters of `New-GraphApplicationCertificate` and `New-GraphLocalCertificate`.
-* Fixed missing surrounding double quotes in generated URI when the `Search` parameter in `Invoke-GraphApiRequest` and `Get-GraphResource` is used to create an argument for `Search` -- seems quotes were not required for requests on `messages` (i.e. mail) but for directory objects they are required. Workaround is to add them to the search parameter value.
-* The `Name` parameter of `New-GraphConnection` was being ignored in certain cases resulting in an unnamed connection -- this has been fixed.
-* The `RedirectUri` property for a connection was not displayed in list views -- this has been fixed.
-* The `Remove-GraphApplicationCertificate` command was removing *all* credentials rather than just a specified credential.
-* The `New-GraphLocalCertificate` and `New-GraphApplicationCertificate` commands now output a fully qualified file system path for the `ExportedCertificatePath` property where before they would use the exact path specified by the `CertificateFilePath` parameter even if it was relative.
-* The `New-GraphApplicationCertificate` command only supported the `NoCredential` parameter when `CertificateFilePath` was specified, but not when `CertOutputDirectory` was specified -- this is fixed.
-* Access token was being requested for every Graph request - fixed to do this only if the token is near expiration.
-* Empty results from `Invoke-GraphRequest` and `Get-GraphRequest` no longer return an object, now null is returned.
+* Fixed broken graph removal impacting downstream `Remove-Graph` command from `autographps` module.
 
 '@
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -121,7 +121,7 @@ jobs:
     displayName: 'Run integration tests'
     inputs:
       targetType: inline
-      script: './test/CI/RunIntegrationTests.ps1 -TestRoot test -TestAppId $(TEST_APPID) -TestAppTenant $(TEST_APPTENANT) -CIBase64TestAppCert $(AutoGraph-CI-Pipeline-Cert-Exp-2024-01-20) -TestParamsPassThru @{OutputFile="$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_INTEGRATION_OUTPUT_FILE)";OutputFormat="NUnitXml"} -verbose'
+      script: './test/CI/RunIntegrationTests.ps1 -TestRoot test -TestAppId $(TEST_APPID) -TestAppTenant $(TEST_APPTENANT) -CIBase64TestAppCert $(CI-AutoGraph-App-Certificate) -TestParamsPassThru @{OutputFile="$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_INTEGRATION_OUTPUT_FILE)";OutputFormat="NUnitXml"} -verbose'
       pwsh: $(USE_POWERSHELL_CORE)
   - task: powershell@2
     displayName: 'Generate sample documents and tests'
@@ -133,7 +133,7 @@ jobs:
     displayName: 'Run sample code integration tests'
     inputs:
       targetType: inline
-      script: './test/CI/RunIntegrationTests.ps1 -TestRoot .test -TestAppId $(TEST_APPID) -TestAppTenant $(TEST_APPTENANT) -CIBase64TestAppCert $(AutoGraph-CI-Pipeline-Cert-Exp-2024-01-20) -TestParamsPassThru @{OutputFile="$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_SAMPLES_OUTPUT_FILE)";OutputFormat="NUnitXml"} -verbose'
+      script: './test/CI/RunIntegrationTests.ps1 -TestRoot .test -TestAppId $(TEST_APPID) -TestAppTenant $(TEST_APPTENANT) -CIBase64TestAppCert $(CI-AutoGraph-App-Certificate) -TestParamsPassThru @{OutputFile="$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_SAMPLES_OUTPUT_FILE)";OutputFormat="NUnitXml"} -verbose'
       pwsh: $(USE_POWERSHELL_CORE)
   - task: PublishTestResults@2
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,7 @@ jobs:
     displayName: 'Install Pester test framework required version'
     inputs:
       targetType: inline
-      script: 'Install-Module Pester -RequiredVersion 4.8.1 -scope currentuser -force'
+      script: 'Install-Module Pester -RequiredVersion 4.8.1 -scope currentuser -force -skippublishercheck'
       pwsh: $(USE_POWERSHELL_CORE)
   - task: powershell@2
     displayName: 'Get updated Pester test framework module version'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
     inputs:
       azureSubscription: 'Azure Free Trial(439deb75-e36b-4569-b075-f2c2448e8a3e)'
       KeyVaultName: 'CI-AutoGraphPS-SDK'
-      SecretsFilter: 'AutoGraph-CI-Pipeline-Cert-Exp-2024-01-20'
+      SecretsFilter: 'CI-AutoGraph-App-Certificate'
       RunAsPreJob: false
   - task: powershell@2
     displayName: 'Show current PowerShell version information'

--- a/src/client/LogicalGraphManager.ps1
+++ b/src/client/LogicalGraphManager.ps1
@@ -109,7 +109,7 @@ ScriptClass LogicalGraphManager {
             throw "Context '$name' cannot be removed because it does not exist"
         }
 
-        if ( ( ! $::.GraphContext |=> GetCurrent ).name -eq $name ) {
+        if ( ! ( $::.GraphContext |=> GetCurrent ).name -eq $name ) {
             throw "Context '$name' cannot be removed because it is the current context"
         }
 


### PR DESCRIPTION
### Description

Fixing multiple bugs, particularly with graph management

### Dependency changes

None.

### Implementation notes

Graph removal internal function was syntactically correct and had apparently regressed with no tests.

### Linked issues

### Checklist

- [ ] New test coverage was added for the new functionality
- [x ] All project tests pass successfully
